### PR TITLE
Lagt til endepunktet /api/innlogget/kontantstotte

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/autentisering/AutentiseringController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/autentisering/AutentiseringController.kt
@@ -18,11 +18,18 @@ class AutentiseringController {
 
     val innlogget = Metrics.counter("innlogget")
     val innloggetUtvidet = Metrics.counter("innlogget.utvidet")
+    val innloggetKontantstøtte = Metrics.counter("innlogget.kontantstotte")
 
     @GetMapping("/innlogget")
     fun verifiserAutentisering(@RequestParam(required = false) søknadstype: Søknadstype?): ResponseEntity<Ressurs<String>> {
         if (søknadstype == Søknadstype.UTVIDET) innloggetUtvidet.increment() else innlogget.increment()
 
+        return ResponseEntity.ok(Ressurs.success("Autentisert kall"))
+    }
+
+    @GetMapping("/innlogget/kontantstotte")
+    fun verifiserAutentiseringKontantstøtte(): ResponseEntity<Ressurs<String>> {
+        innloggetKontantstøtte.increment()
         return ResponseEntity.ok(Ressurs.success("Autentisert kall"))
     }
 }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Vi teller hvor mange brukere som logger seg inn i løsningen. For å kunne skille mellom innloggede brukere for barnetrygd og kontantstøtte har jeg laget et eget endepunkt for kontantstøtte som øker telleren `innlogget.kontantstotte` hver gang en bruker logger seg inn.