### PR TITLE
Henter kun barn med alder under aldersgrense for ytelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/controllers/PersonopplysningerController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/controllers/PersonopplysningerController.kt
@@ -1,14 +1,17 @@
 package no.nav.familie.baks.soknad.api.controllers
 
 import no.nav.familie.baks.soknad.api.domene.Person
+import no.nav.familie.baks.soknad.api.domene.Ytelse
 import no.nav.familie.baks.soknad.api.services.pdl.PersonopplysningerService
 import no.nav.familie.baks.soknad.api.util.TokenBehandler
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -16,12 +19,26 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping(path = ["/api"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class PersonopplysningerController(private val personopplysningerService: PersonopplysningerService) {
 
+    // TODO: Fjerne denne når ba-soknad og ks-soknad er oppdatert
     @PostMapping("/personopplysning")
     fun personInfo(): ResponseEntity<Ressurs<Person?>> {
         return ResponseEntity.ok(
             Ressurs.success(
                 personopplysningerService.hentPersoninfo(
-                    TokenBehandler.hentFnr()
+                    TokenBehandler.hentFnr(),
+                    Ytelse.BARNETRYGD
+                )
+            )
+        )
+    }
+
+    @GetMapping("/personopplysning")
+    fun personInfo(@RequestParam ytelse: Ytelse): ResponseEntity<Ressurs<Person?>> {
+        return ResponseEntity.ok(
+            Ressurs.success(
+                personopplysningerService.hentPersoninfo(
+                    TokenBehandler.hentFnr(),
+                    ytelse
                 )
             )
         )

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/domene/Ytelse.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/domene/Ytelse.kt
@@ -1,0 +1,13 @@
+package no.nav.familie.baks.soknad.api.domene
+
+import java.time.Period
+
+enum class Ytelse(val aldersgrense: Aldersgrense) {
+    BARNETRYGD(Aldersgrense(18, 0)),
+    KONTANTSTOTTE(Aldersgrense(2, 6))
+}
+
+data class Aldersgrense(val years: Int, val months: Int) {
+
+    fun toTotalMonths() = Period.of(years, months, 0).toTotalMonths()
+}

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/services/pdl/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/services/pdl/PersonopplysningerService.kt
@@ -1,19 +1,20 @@
 package no.nav.familie.baks.soknad.api.services.pdl
 
-import java.time.LocalDate
-import java.time.Period
-import java.time.format.DateTimeFormatter
 import no.nav.familie.baks.soknad.api.clients.kodeverk.KodeverkClient
 import no.nav.familie.baks.soknad.api.clients.pdl.PdlApp2AppClient
 import no.nav.familie.baks.soknad.api.clients.pdl.PdlBrukerClient
 import no.nav.familie.baks.soknad.api.clients.pdl.PdlDoedsafall
 import no.nav.familie.baks.soknad.api.domene.Barn
 import no.nav.familie.baks.soknad.api.domene.Person
+import no.nav.familie.baks.soknad.api.domene.Ytelse
 import no.nav.familie.baks.soknad.api.services.kodeverk.CachedKodeverkService
 import no.nav.familie.baks.soknad.api.services.pdl.mapper.PdlBarnMapper
 import no.nav.familie.baks.soknad.api.services.pdl.mapper.PdlMapper
 import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
 import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.time.Period
+import java.time.format.DateTimeFormatter
 
 @Service
 class PersonopplysningerService(
@@ -23,12 +24,13 @@ class PersonopplysningerService(
 ) {
 
     val kodeverkService = CachedKodeverkService(kodeverkClient)
-    fun hentPersoninfo(personIdent: String, somSystem: Boolean = false): Person {
+    fun hentPersoninfo(personIdent: String, ytelse: Ytelse, somSystem: Boolean = false): Person {
         val response = if (somSystem) pdlApp2AppClient.hentPerson(personIdent) else pdlClient.hentPerson(personIdent)
 
         val barnTilSoeker = hentBarnTilSoeker(
             fnrBarn = PdlMapper.mapFnrBarn(response.data.person!!.forelderBarnRelasjon),
-            sokerAdresse = response.data.person.bostedsadresse.firstOrNull()
+            sokerAdresse = response.data.person.bostedsadresse.firstOrNull(),
+            ytelse
         )
 
         return response.data.person.let {
@@ -36,12 +38,14 @@ class PersonopplysningerService(
         }
     }
 
-    fun hentBarnTilSoeker(fnrBarn: List<String>, sokerAdresse: Bostedsadresse?): Set<Barn> {
+    fun hentBarnTilSoeker(fnrBarn: List<String>, sokerAdresse: Bostedsadresse?, ytelse: Ytelse): Set<Barn> {
         return fnrBarn
             .map { ident -> pdlApp2AppClient.hentPerson(ident) }
             .filter {
-                erBarnILive(it.data.person?.doedsfall) &&
-                    erUnderAtten(parseIsoDato(it.data.person?.foedsel?.firstOrNull()?.foedselsdato))
+                erBarnILive(it.data.person?.doedsfall) && erBarnetsAlderUnderAldersgrenseForYtelse(
+                    parseIsoDato(it.data.person?.foedsel?.firstOrNull()?.foedselsdato),
+                    ytelse
+                )
             }
             .map { PdlBarnMapper.mapBarn(it, sokerAdresse) }.toSet()
     }
@@ -50,13 +54,12 @@ class PersonopplysningerService(
         return doedsfall?.firstOrNull()?.doedsdato == null
     }
 
-    fun erUnderAtten(fødselsdato: LocalDate?): Boolean {
+    fun erBarnetsAlderUnderAldersgrenseForYtelse(fødselsdato: LocalDate?, ytelse: Ytelse): Boolean {
         if (fødselsdato == null) {
             return false
         }
         val alder = Period.between(fødselsdato, LocalDate.now())
-        val alderIÅr = alder.years
-        return alderIÅr < 18
+        return alder.toTotalMonths() < ytelse.aldersgrense.toTotalMonths()
     }
 
     fun parseIsoDato(dato: String?): LocalDate? {

--- a/src/test/kotlin/no/nav/familie/baks/soknad/api/personopplysning/PersonopplysningerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/soknad/api/personopplysning/PersonopplysningerServiceTest.kt
@@ -2,11 +2,21 @@ package no.nav.familie.baks.soknad.api.personopplysning
 
 import io.mockk.every
 import io.mockk.mockk
-import java.io.File
 import no.nav.familie.baks.soknad.api.clients.kodeverk.KodeverkClient
+import no.nav.familie.baks.soknad.api.clients.pdl.ADRESSEBESKYTTELSEGRADERING
+import no.nav.familie.baks.soknad.api.clients.pdl.Adressebeskyttelse
+import no.nav.familie.baks.soknad.api.clients.pdl.FAMILIERELASJONSROLLE
 import no.nav.familie.baks.soknad.api.clients.pdl.PdlApp2AppClient
 import no.nav.familie.baks.soknad.api.clients.pdl.PdlBrukerClient
+import no.nav.familie.baks.soknad.api.clients.pdl.PdlFamilierelasjon
+import no.nav.familie.baks.soknad.api.clients.pdl.PdlFolkeregisteridentifikator
+import no.nav.familie.baks.soknad.api.clients.pdl.PdlFødselsDato
 import no.nav.familie.baks.soknad.api.clients.pdl.PdlHentPersonResponse
+import no.nav.familie.baks.soknad.api.clients.pdl.PdlNavn
+import no.nav.familie.baks.soknad.api.clients.pdl.PdlPerson
+import no.nav.familie.baks.soknad.api.clients.pdl.PdlPersonData
+import no.nav.familie.baks.soknad.api.clients.pdl.PdlStatsborgerskap
+import no.nav.familie.baks.soknad.api.domene.Ytelse
 import no.nav.familie.baks.soknad.api.services.kodeverk.CachedKodeverkService
 import no.nav.familie.baks.soknad.api.services.pdl.PersonopplysningerService
 import no.nav.familie.baks.soknad.api.services.pdl.mapper.PdlBarnMapper
@@ -21,6 +31,9 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.io.File
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 class PersonopplysningerServiceTest {
 
@@ -48,7 +61,7 @@ class PersonopplysningerServiceTest {
         every { pdlClient.hentPerson(any()) } returns pdlMockFor("pdlPersonMedFlereRelasjoner")
         every { barnePdlClient.hentPerson("12345678910") } returns pdlMockFor("pdlPersonBarn")
         every { kodeverkClient.hentPostnummer() } returns kodeverkMockFor("kodeverkPostnummerRespons")
-        val person = personopplysningerService.hentPersoninfo("1")
+        val person = personopplysningerService.hentPersoninfo("1", Ytelse.BARNETRYGD)
 
         assertEquals(1, person.barn.size)
         assertEquals("ENGASJERT FYR", person.barn.first().navn)
@@ -59,7 +72,7 @@ class PersonopplysningerServiceTest {
     fun `hentPersonInfo skal returnere tom liste hvis det er familierelasjoner, men ingen barn`() {
         every { pdlClient.hentPerson(any()) } returns pdlMockFor("pdlPersonMedRelasjonerIngenBarn")
         every { kodeverkClient.hentPostnummer() } returns kodeverkMockFor("kodeverkPostnummerRespons")
-        val person = personopplysningerService.hentPersoninfo("1")
+        val person = personopplysningerService.hentPersoninfo("1", Ytelse.BARNETRYGD)
         assertTrue(person.barn.isEmpty())
     }
 
@@ -67,7 +80,7 @@ class PersonopplysningerServiceTest {
     fun `hentPersonInfo skal returnere ident`() {
         every { pdlClient.hentPerson(any()) } returns pdlMockFor("pdlPersonMedRelasjonerIngenBarn")
         every { kodeverkClient.hentPostnummer() } returns kodeverkMockFor("kodeverkPostnummerRespons")
-        val person = personopplysningerService.hentPersoninfo("1")
+        val person = personopplysningerService.hentPersoninfo("1", Ytelse.BARNETRYGD)
         assertEquals("23058518298", person.ident)
     }
 
@@ -75,7 +88,7 @@ class PersonopplysningerServiceTest {
     fun `hentPersonInfo skal returnere liste med statsborgerskap hvis det er flere fra pdl`() {
         every { pdlClient.hentPerson(any()) } returns pdlMockFor("pdlPersonMedFlereStatsborgerskap")
         every { kodeverkClient.hentPostnummer() } returns kodeverkMockFor("kodeverkPostnummerRespons")
-        val person = personopplysningerService.hentPersoninfo("1")
+        val person = personopplysningerService.hentPersoninfo("1", Ytelse.BARNETRYGD)
         assertEquals(person!!.statsborgerskap.size, 2)
         assertEquals(person.statsborgerskap[0].landkode, "NOR")
         assertEquals(person.statsborgerskap[1].landkode, "SWE")
@@ -85,7 +98,7 @@ class PersonopplysningerServiceTest {
     fun `hentPersonInfo skal returnere tom liste hvis ingen familierelasjoner`() {
         every { pdlClient.hentPerson(any()) } returns pdlMockFor("pdlPersonUtenRelasjoner")
         every { kodeverkClient.hentPostnummer() } returns kodeverkMockFor("kodeverkPostnummerRespons")
-        val person = personopplysningerService.hentPersoninfo("1")
+        val person = personopplysningerService.hentPersoninfo("1", Ytelse.BARNETRYGD)
         assertTrue(person!!.barn.isEmpty())
     }
 
@@ -94,7 +107,7 @@ class PersonopplysningerServiceTest {
         every { pdlClient.hentPerson(any()) } returns pdlMockFor("pdlBrukerMedDoedBarn")
         every { barnePdlClient.hentPerson("12345678910") } returns pdlMockFor("pdlBarnErDoed")
         every { kodeverkClient.hentPostnummer() } returns kodeverkMockFor("kodeverkPostnummerRespons")
-        val person = personopplysningerService.hentPersoninfo("23058518298")
+        val person = personopplysningerService.hentPersoninfo("23058518298", Ytelse.BARNETRYGD)
         assertEquals(person.barn.size, 0)
     }
 
@@ -103,7 +116,7 @@ class PersonopplysningerServiceTest {
         every { pdlClient.hentPerson(any()) } returns pdlMockFor("pdlBarnErOverAtten")
         every { barnePdlClient.hentPerson("12345678910") } returns pdlMockFor("pdlBrukerMedBarnOverAtten")
         every { kodeverkClient.hentPostnummer() } returns kodeverkMockFor("kodeverkPostnummerRespons")
-        val person = personopplysningerService.hentPersoninfo("23058518298")
+        val person = personopplysningerService.hentPersoninfo("23058518298", Ytelse.BARNETRYGD)
         assertEquals(person.barn.size, 0)
     }
 
@@ -183,7 +196,7 @@ class PersonopplysningerServiceTest {
         every { kodeverkClient.hentPostnummer() } returns kodeverkMockFor("kodeverkPostnummerRespons")
         every { pdlClient.hentPerson(any()) } returns pdlMockFor("pdlPersonUtenRelasjonerGradertAdresse")
 
-        val person = personopplysningerService.hentPersoninfo("1")
+        val person = personopplysningerService.hentPersoninfo("1", Ytelse.BARNETRYGD)
         assertTrue(person.adressebeskyttelse)
     }
 
@@ -192,17 +205,19 @@ class PersonopplysningerServiceTest {
         every { kodeverkClient.hentPostnummer() } returns kodeverkMockFor("kodeverkPostnummerRespons")
         every { pdlClient.hentPerson(any()) } returns pdlMockFor("pdlSoekerHarAdresseOgAdressebeskyttelse")
 
-        val person = personopplysningerService.hentPersoninfo("1")
+        val person = personopplysningerService.hentPersoninfo("1", Ytelse.BARNETRYGD)
         assertEquals(person.adresse, null)
         assertEquals(person.adressebeskyttelse, true)
     }
 
     private fun pdlMockFor(filNavn: String) = mapper.readValue(
-        File(getFile("pdl/$filNavn.json")), PdlHentPersonResponse::class.java
+        File(getFile("pdl/$filNavn.json")),
+        PdlHentPersonResponse::class.java
     )
 
     private fun kodeverkMockFor(filNavn: String) = mapper.readValue(
-        File(getFile("kodeverk/$filNavn.json")), KodeverkDto::class.java
+        File(getFile("kodeverk/$filNavn.json")),
+        KodeverkDto::class.java
     )
 
     private fun getFile(name: String): String {
@@ -215,7 +230,7 @@ class PersonopplysningerServiceTest {
         every { barnePdlClient.hentPerson("12345678910") } returns pdlMockFor("pdlPersonBarn")
         every { kodeverkClient.hentPostnummer() } returns kodeverkMockFor("kodeverkPostnummerRespons")
 
-        val person = personopplysningerService.hentPersoninfo("1")
+        val person = personopplysningerService.hentPersoninfo("1", Ytelse.BARNETRYGD)
         assertEquals(person.adresse?.adressenavn, "1223")
         assertEquals(person.adresse?.husnummer, "E22")
         assertEquals(person.adresse?.husbokstav, "tillegg")
@@ -229,7 +244,7 @@ class PersonopplysningerServiceTest {
         every { barnePdlClient.hentPerson("12345678910") } returns pdlMockFor("pdlBarnHarAdresseBeskyttelse")
         every { kodeverkClient.hentPostnummer() } returns kodeverkMockFor("kodeverkPostnummerRespons")
 
-        val person = personopplysningerService.hentPersoninfo("1")
+        val person = personopplysningerService.hentPersoninfo("1", Ytelse.BARNETRYGD)
         assertTrue(person.barn.toList()[0].adressebeskyttelse)
         assertFalse(person.barn.toList()[0].borMedSøker)
     }
@@ -238,7 +253,7 @@ class PersonopplysningerServiceTest {
     fun `hentPerson sine returnerer rett matrikkeladresse`() {
         every { pdlClient.hentPerson(any()) } returns pdlMockFor("pdlMedMatrikkelAdresse")
         every { kodeverkClient.hentPostnummer() } returns kodeverkMockFor("kodeverkPostnummerRespons")
-        val person = personopplysningerService.hentPersoninfo("1")
+        val person = personopplysningerService.hentPersoninfo("1", Ytelse.BARNETRYGD)
         assertEquals(person.adresse?.adressenavn, "Tilleggsnavn")
         assertEquals(person.adresse?.bruksenhetsnummer, "1456")
         assertEquals(person.adresse?.postnummer, "4971")
@@ -251,9 +266,89 @@ class PersonopplysningerServiceTest {
         every { barnePdlClient.hentPerson("12345678910") } returns pdlMockFor("pdlBarnHarAdresseBeskyttelse")
         every { kodeverkClient.hentPostnummer() } returns kodeverkMockFor("kodeverkPostnummerRespons")
 
-        val person = personopplysningerService.hentPersoninfo("1")
+        val person = personopplysningerService.hentPersoninfo("1", Ytelse.BARNETRYGD)
         assertTrue(person.barn.toList()[0].adressebeskyttelse)
         assertEquals(person.barn.toList()[0].navn, null)
         assertFalse(person.barn.toList()[0].borMedSøker)
+    }
+
+    @Test
+    fun `hentPerson skal ikke returnere barn som er 2 år og 6 mnd`() {
+        every { barnePdlClient.hentPerson("23042018298") } returns lagPdlHentPersonRespons(
+            "23042018298",
+            LocalDate.now().minusYears(2).minusMonths(6)
+        )
+        every { pdlClient.hentPerson("23058518298") } returns lagPdlHentPersonRespons(
+            "23058518298",
+            LocalDate.of(1985, 5, 23),
+            listOf(
+                PdlFamilierelasjon(
+                    "23042018298",
+                    FAMILIERELASJONSROLLE.BARN
+                )
+            )
+        )
+        every { kodeverkClient.hentPostnummer() } returns kodeverkMockFor("kodeverkPostnummerRespons")
+        val person = personopplysningerService.hentPersoninfo("23058518298", Ytelse.KONTANTSTOTTE)
+        assertEquals(person.barn.size, 0)
+    }
+
+    @Test
+    fun `hentPerson skal returnere barn som er 1 dag mindre enn 2 år og 6 mnd`() {
+        every { barnePdlClient.hentPerson("23042018298") } returns lagPdlHentPersonRespons(
+            "23042018298",
+            LocalDate.now().minusYears(2).minusMonths(6).plusDays(1)
+        )
+        every { pdlClient.hentPerson("23058518298") } returns lagPdlHentPersonRespons(
+            "23058518298",
+            LocalDate.of(1985, 5, 23),
+            listOf(
+                PdlFamilierelasjon(
+                    "23042018298",
+                    FAMILIERELASJONSROLLE.BARN
+                )
+            )
+        )
+        every { kodeverkClient.hentPostnummer() } returns kodeverkMockFor("kodeverkPostnummerRespons")
+        val person = personopplysningerService.hentPersoninfo("23058518298", Ytelse.KONTANTSTOTTE)
+        assertEquals(1, person.barn.size)
+    }
+
+    fun lagPdlHentPersonRespons(
+        fnr: String,
+        fødselsdato: LocalDate,
+        forelderBarnRelasjoner: List<PdlFamilierelasjon> = emptyList()
+    ): PdlHentPersonResponse {
+        return PdlHentPersonResponse(
+            data = PdlPerson(
+                person = PdlPersonData(
+                    navn = listOf(PdlNavn(fornavn = "ENGASJERT", etternavn = "FYR")),
+                    adressebeskyttelse = listOf(
+                        Adressebeskyttelse(ADRESSEBESKYTTELSEGRADERING.UGRADERT)
+                    ),
+                    folkeregisteridentifikator = listOf(PdlFolkeregisteridentifikator(fnr)),
+                    bostedsadresse = listOf(
+                        Bostedsadresse(
+                            vegadresse = Vegadresse(
+                                3L,
+                                "E22",
+                                "A",
+                                "1456",
+                                "Testgate",
+                                kommunenummer = "12",
+                                tilleggsnavn = "Tilleggsnavn",
+                                postnummer = "4971"
+                            )
+                        )
+                    ),
+                    statsborgerskap = listOf(PdlStatsborgerskap("NOR")),
+                    foedsel = listOf(PdlFødselsDato(fødselsdato.format(DateTimeFormatter.ISO_DATE))),
+                    doedsfall = emptyList(),
+                    sivilstand = emptyList(),
+                    forelderBarnRelasjon = forelderBarnRelasjoner
+                )
+            ),
+            errors = null
+        )
     }
 }


### PR DESCRIPTION
Har utvidet `PersonopplysningerController` og `PersonopplysningerService` slik at vi kun inkluderer barn som er yngre enn aldersgrensen til ytelsen. Under 18 år for barnetrygd og under 2 år og 6 mnd for kontantstøtte.