### PR TITLE
Fjernet unødvendig konfigurasjon av ingress

### DIFF
--- a/dev-gcp-teamfamilie.yaml
+++ b/dev-gcp-teamfamilie.yaml
@@ -37,8 +37,6 @@ spec:
     requests:
       memory: 512Mi
       cpu: 200m
-  ingresses:
-    - https://familie-baks-soknad-api.dev.nav.no
   accessPolicy:
     inbound:
       rules:


### PR DESCRIPTION
Frontend kommuniserer med baks-soknad-api via service-discovery og ingress er ikke nødvendig.