### PR TITLE
Chore/fjern støtte for selvbetjening token

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/autentisering/AutentiseringController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/autentisering/AutentiseringController.kt
@@ -16,8 +16,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping(path = ["/api"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @RequiredIssuers(
-    ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_TOKENX, claimMap = ["acr=Level4"]),
-    ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_SELVBETJENING, claimMap = ["acr=Level4"])
+    ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_TOKENX, claimMap = ["acr=Level4"])
 )
 class AutentiseringController {
 

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/controllers/KodeverkController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/controllers/KodeverkController.kt
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequiredIssuers(
-    ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_SELVBETJENING, claimMap = ["acr=Level4"]),
     ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_TOKENX, claimMap = ["acr=Level4"])
 )
 @RequestMapping(path = ["/api/kodeverk"], produces = [MediaType.APPLICATION_JSON_VALUE])

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/controllers/PersonopplysningerController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/controllers/PersonopplysningerController.kt
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequiredIssuers(
-    ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_SELVBETJENING, claimMap = ["acr=Level4"]),
     ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_TOKENX, claimMap = ["acr=Level4"])
 )
 @RequestMapping(path = ["/api"], produces = [MediaType.APPLICATION_JSON_VALUE])

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/controllers/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/controllers/SøknadController.kt
@@ -2,10 +2,7 @@ package no.nav.familie.baks.soknad.api.controllers
 
 import no.nav.familie.baks.soknad.api.clients.mottak.MottakClient
 import no.nav.familie.baks.soknad.api.domene.Kvittering
-import no.nav.familie.kontrakter.ba.søknad.v8.Søknad as BarnetrygdSøknadV8
 import no.nav.familie.kontrakter.felles.Ressurs
-import no.nav.familie.kontrakter.ks.søknad.v2.KontantstøtteSøknad as KontantstøtteSøknadV2
-import no.nav.familie.kontrakter.ks.søknad.v3.KontantstøtteSøknad as KontantstøtteSøknadV3
 import no.nav.familie.sikkerhet.EksternBrukerUtils
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.api.RequiredIssuers
@@ -15,11 +12,13 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import no.nav.familie.kontrakter.ba.søknad.v8.Søknad as BarnetrygdSøknadV8
+import no.nav.familie.kontrakter.ks.søknad.v2.KontantstøtteSøknad as KontantstøtteSøknadV2
+import no.nav.familie.kontrakter.ks.søknad.v3.KontantstøtteSøknad as KontantstøtteSøknadV3
 
 @RestController
 @RequestMapping(path = ["/api"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @RequiredIssuers(
-    ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_SELVBETJENING, claimMap = ["acr=Level4"]),
     ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_TOKENX, claimMap = ["acr=Level4"])
 )
 class SøknadController(private val mottakClient: MottakClient) {

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/controllers/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/controllers/SøknadController.kt
@@ -2,7 +2,10 @@ package no.nav.familie.baks.soknad.api.controllers
 
 import no.nav.familie.baks.soknad.api.clients.mottak.MottakClient
 import no.nav.familie.baks.soknad.api.domene.Kvittering
+import no.nav.familie.kontrakter.ba.søknad.v8.Søknad as BarnetrygdSøknadV8
 import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.ks.søknad.v2.KontantstøtteSøknad as KontantstøtteSøknadV2
+import no.nav.familie.kontrakter.ks.søknad.v3.KontantstøtteSøknad as KontantstøtteSøknadV3
 import no.nav.familie.sikkerhet.EksternBrukerUtils
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.api.RequiredIssuers
@@ -12,9 +15,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import no.nav.familie.kontrakter.ba.søknad.v8.Søknad as BarnetrygdSøknadV8
-import no.nav.familie.kontrakter.ks.søknad.v2.KontantstøtteSøknad as KontantstøtteSøknadV2
-import no.nav.familie.kontrakter.ks.søknad.v3.KontantstøtteSøknad as KontantstøtteSøknadV3
 
 @RestController
 @RequestMapping(path = ["/api"], produces = [MediaType.APPLICATION_JSON_VALUE])

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/helsesjekk/HelsesjekkController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/helsesjekk/HelsesjekkController.kt
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/helse")
 @RequiredIssuers(
-    ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_SELVBETJENING, claimMap = ["acr=Level4"]),
     ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_TOKENX, claimMap = ["acr=Level4"])
 )
 class HelsesjekkController(

--- a/src/main/resources/application-lokal.yaml
+++ b/src/main/resources/application-lokal.yaml
@@ -27,11 +27,6 @@ AZURE_OPENID_CONFIG_TOKEN_ENDPOINT: http://localhost
 
 no.nav.security.jwt:
   issuer:
-    selvbetjening:
-      discoveryurl: http://localhost:${mock-oauth2-server.port}/selvbetjening/.well-known/openid-configuration
-      accepted_audience: aud-localhost
-      cookie_name: localhost-idtoken
-      proxyurl:
     tokenx:
       discoveryurl: http://localhost:${mock-oauth2-server.port}/tokenx/.well-known/openid-configuration
       accepted_audience: familie-app

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,10 +25,6 @@ KODEVERK_URL: dummy
 
 no.nav.security.jwt:
   issuer:
-    selvbetjening:
-      discoveryurl: ${LOGINSERVICE_IDPORTEN_DISCOVERY_URL}
-      accepted_audience: ${LOGINSERVICE_IDPORTEN_AUDIENCE}
-      cookie_name: selvbetjening-idtoken
     tokenx:
       discovery-url: ${TOKEN_X_WELL_KNOWN_URL}
       accepted-audience: ${TOKEN_X_CLIENT_ID}


### PR DESCRIPTION
Vi har gått over til å bruke tokenx for både barnetrygd og kontantstøtte så trenger ikke lenger å støtte bruk av selvbetjening-token.
