### PR TITLE
Oppdatert til spring-boot 3.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.6</version>
+        <version>3.0.5</version>
     </parent>
 
     <properties>
@@ -20,10 +20,10 @@
         <changelist>-SNAPSHOT</changelist>
         <jvmTarget>17</jvmTarget>
         <java.version>17</java.version>
-        <kontrakter.version>2.0_20230404085325_67043a3</kontrakter.version>
-        <felles.version>1.20230117091843_19b020f</felles.version>
+        <kontrakter.version>3.0_20230404085353_8385387-JAKARTA</kontrakter.version>
+        <felles.version>2.20230210162649_a258d57-SPRING_BOOT_3</felles.version>
         <mockk.version>1.12.5</mockk.version>
-        <token-validation-spring.version>2.0.21</token-validation-spring.version>
+        <token-validation-spring.version>3.0.3</token-validation-spring.version>
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->
         <sonar.projectKey>${SONAR_PROJECTKEY}</sonar.projectKey>
         <sonar.organization>navit</sonar.organization>
@@ -31,7 +31,7 @@
         <start-class>no.nav.familie.baks.soknad.api.LauncherKt</start-class>
         <!--suppress UnresolvedMavenProperty Ligger som secret i github-->
         <sonar.login>${SONAR_LOGIN}</sonar.login>
-        <kotlin.version>1.8.0</kotlin.version>
+        <kotlin.version>1.8.20</kotlin.version>
         <!-- Må settes for å kunne kjøre opp mock-oauth2-server i unit-tester -->
         <okhttp3.version>4.9.1</okhttp3.version>
         <!-- Må settes for å kunne kjøre opp mock-oauth2-server i unit-tester -->
@@ -110,6 +110,11 @@
             <groupId>no.nav.security</groupId>
             <artifactId>token-validation-spring</artifactId>
             <version>${token-validation-spring.version}</version>
+        </dependency>
+        <!-- https://github.com/spring-projects/spring-boot/issues/33044#issuecomment-1379812611 -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
         </dependency>
 
         <!-- Test -->
@@ -193,12 +198,12 @@
                 <plugin>
                     <groupId>org.sonarsource.scanner.maven</groupId>
                     <artifactId>sonar-maven-plugin</artifactId>
-                    <version>3.7.0.1746</version>
+                    <version>3.9.1.2184</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.7</version>
+                    <version>0.8.9</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -286,7 +291,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.7</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>ktlint</id>

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/kodeverk/KodeverkClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/kodeverk/KodeverkClient.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.baks.soknad.api.clients.kodeverk
 
+import java.net.URI
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.http.client.Pingable
 import no.nav.familie.http.util.UriUtil
@@ -7,7 +8,6 @@ import no.nav.familie.kontrakter.felles.kodeverk.KodeverkDto
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestOperations
-import java.net.URI
 
 @Component
 class KodeverkClient(

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/kodeverk/KodeverkClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/kodeverk/KodeverkClient.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.baks.soknad.api.clients.kodeverk
 
-import java.net.URI
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.http.client.Pingable
 import no.nav.familie.http.util.UriUtil
@@ -8,6 +7,7 @@ import no.nav.familie.kontrakter.felles.kodeverk.KodeverkDto
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestOperations
+import java.net.URI
 
 @Component
 class KodeverkClient(
@@ -33,7 +33,7 @@ class KodeverkClient(
         val query = if (medHistorikk) QUERY_MED_HISTORIKK else QUERY
         return UriUtil.uri(
             base = kodeverkUri,
-            path = "/api/v1/kodeverk/$kodeverksnavn/koder/betydninger",
+            path = "api/v1/kodeverk/$kodeverksnavn/koder/betydninger",
             query = query
         )
     }

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/mottak/MottakClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/mottak/MottakClient.kt
@@ -1,14 +1,11 @@
 package no.nav.familie.baks.soknad.api.clients.mottak
 
 import com.fasterxml.jackson.databind.JsonNode
-import java.net.URI
 import no.nav.familie.baks.soknad.api.domene.Kvittering
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.http.client.MultipartBuilder
-import no.nav.familie.kontrakter.ba.søknad.v8.Søknad as SøknadV8
+import no.nav.familie.http.util.UriUtil
 import no.nav.familie.kontrakter.felles.Ressurs
-import no.nav.familie.kontrakter.ks.søknad.v3.KontantstøtteSøknad as KontantstøtteSøknadV3
-import no.nav.familie.kontrakter.ks.søknad.v4.KontantstøtteSøknad as KontantstøtteSøknadV4
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -17,6 +14,10 @@ import org.springframework.stereotype.Component
 import org.springframework.util.MultiValueMap
 import org.springframework.web.client.RestOperations
 import org.springframework.web.client.exchange
+import java.net.URI
+import no.nav.familie.kontrakter.ba.søknad.v8.Søknad as SøknadV8
+import no.nav.familie.kontrakter.ks.søknad.v3.KontantstøtteSøknad as KontantstøtteSøknadV3
+import no.nav.familie.kontrakter.ks.søknad.v4.KontantstøtteSøknad as KontantstøtteSøknadV4
 
 @Component
 class MottakClient(
@@ -25,7 +26,7 @@ class MottakClient(
 ) :
     AbstractPingableRestClient(restOperations, "integrasjon") {
 
-    override val pingUri: URI = URI.create("$mottakBaseUrl/api/soknad")
+    override val pingUri: URI = UriUtil.uri(URI.create(mottakBaseUrl), "api/soknad")
 
     override fun ping() {
         try {
@@ -38,17 +39,17 @@ class MottakClient(
     }
 
     fun sendBarnetrygdSøknad(søknad: SøknadV8): Ressurs<Kvittering> {
-        val uri: URI = URI.create("$mottakBaseUrl/api/soknad/v8")
+        val uri: URI = UriUtil.uri(URI.create(mottakBaseUrl), "api/soknad/v8")
         return håndterSendingAvSøknad(uri = uri, søknad = søknad)
     }
 
     fun sendKontantstøtteSøknad(kontantstøtteSøknad: KontantstøtteSøknadV3): Ressurs<Kvittering> {
-        val uri: URI = URI.create("$mottakBaseUrl/api/kontantstotte/soknad/v3")
+        val uri: URI = UriUtil.uri(URI.create(mottakBaseUrl), "api/kontantstotte/soknad/v3")
         return håndterSendingAvSøknad(uri = uri, søknad = kontantstøtteSøknad)
     }
 
     fun sendKontantstøtteSøknad(kontantstøtteSøknad: KontantstøtteSøknadV4): Ressurs<Kvittering> {
-        val uri: URI = URI.create("$mottakBaseUrl/api/kontantstotte/soknad/v4")
+        val uri: URI = UriUtil.uri(URI.create(mottakBaseUrl), "api/kontantstotte/soknad/v4")
         return håndterSendingAvSøknad(uri = uri, søknad = kontantstøtteSøknad)
     }
 

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/pdl/PdlClient.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.baks.soknad.api.clients.pdl
 
 import com.fasterxml.jackson.databind.JsonNode
-import java.net.URI
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.http.client.Pingable
 import org.apache.commons.lang3.StringUtils
@@ -11,6 +10,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.web.client.RestOperations
 import org.springframework.web.client.exchange
+import java.net.URI
 
 abstract class PdlClient(
     pdlBaseUrl: String,
@@ -21,7 +21,7 @@ abstract class PdlClient(
     private val pdlUri = URI.create("$pdlBaseUrl/graphql")
 
     fun hentPerson(personIdent: String): PdlHentPersonResponse {
-        val query = this::class.java.getResource("/pdl/hent-person-med-relasjoner.graphql").readText().graphqlCompatible()
+        val query = this::class.java.getResource("pdl/hent-person-med-relasjoner.graphql").readText().graphqlCompatible()
 
         val pdlPersonRequest = PdlPersonRequest(
             variables = PdlPersonRequestVariables(personIdent),

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/pdl/PdlClient.kt
@@ -1,8 +1,10 @@
 package no.nav.familie.baks.soknad.api.clients.pdl
 
 import com.fasterxml.jackson.databind.JsonNode
+import java.net.URI
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.http.client.Pingable
+import no.nav.familie.http.util.UriUtil
 import org.apache.commons.lang3.StringUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -10,7 +12,6 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.web.client.RestOperations
 import org.springframework.web.client.exchange
-import java.net.URI
 
 abstract class PdlClient(
     pdlBaseUrl: String,
@@ -18,10 +19,10 @@ abstract class PdlClient(
 ) :
     AbstractPingableRestClient(restOperations, "pdl.integrasjon"), Pingable {
 
-    private val pdlUri = URI.create("$pdlBaseUrl/graphql")
+    private val pdlUri = UriUtil.uri(base = URI.create(pdlBaseUrl), path = "graphql")
 
     fun hentPerson(personIdent: String): PdlHentPersonResponse {
-        val query = this::class.java.getResource("pdl/hent-person-med-relasjoner.graphql").readText().graphqlCompatible()
+        val query = this::class.java.getResource("/pdl/hent-person-med-relasjoner.graphql").readText().graphqlCompatible()
 
         val pdlPersonRequest = PdlPersonRequest(
             variables = PdlPersonRequestVariables(personIdent),

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/config/ApplicationConfig.kt
@@ -70,7 +70,7 @@ internal class ApplicationConfig {
     }
 
     @Bean("tokenExchange")
-    fun restTemplate(
+    fun tokenExchangeRestTemplate(
         bearerTokenExchangeClientInterceptor: BearerTokenExchangeClientInterceptor,
         mdcValuesPropagatingClientInterceptor: MdcValuesPropagatingClientInterceptor,
         consumerIdClientInterceptor: ConsumerIdClientInterceptor


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
* Bumpet `spring-boot-starter-parent` fra 2.6.6 -> 3.0.5
* Oppdatert avhengighetene `familie-kontrakter` og `familie-felles` til å bruke SpringBoot-kompatibel versjon
* Lagt til avhengigheten `org.eclipse.jetty.jetty-server` for å fikse oppstart av app etter oppgradering til SpringBoot 3
* Endret navn på `@Bean` i `ApplicationConfig` slik at vi ikke har flere beans med samme navn. (Oppstart feiler ellers)
* Sørger for at vi ikke forsøker å kalle på andre tjenester med dobbel-slash før path.
