### PR TITLE
Øker cachestørrelsen for kodeverk

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/config/CacheConfig.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/config/CacheConfig.kt
@@ -34,7 +34,7 @@ class CacheConfig {
         override fun createConcurrentMapCache(name: String): Cache {
             val concurrentMap = Caffeine
                 .newBuilder()
-                .maximumSize(1000)
+                .maximumSize(10500)
                 .expireAfterWrite(24, TimeUnit.HOURS)
                 .recordStats().build<Any, Any>().asMap()
             return ConcurrentMapCache(name, concurrentMap, true)


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Siden den skal cache postnummer, så er det ca 6000 aktive postnummer, men potensiale til opp til 9999. Så 1000 blir nok litt lite. I tillegg så caches EØS land og alle land.
