### PR TITLE
Reduser ressurs request

### DIFF
--- a/dev-gcp-teamfamilie.yaml
+++ b/dev-gcp-teamfamilie.yaml
@@ -32,7 +32,6 @@ spec:
   resources:
     limits:
       memory: 500Mi
-      cpu: "1"
     requests:
       memory: 300Mi
       cpu: 10m

--- a/dev-gcp-teamfamilie.yaml
+++ b/dev-gcp-teamfamilie.yaml
@@ -31,11 +31,11 @@ spec:
       enabled: true
   resources:
     limits:
-      memory: 1024Mi
+      memory: 500Mi
       cpu: "1"
     requests:
-      memory: 512Mi
-      cpu: 200m
+      memory: 300Mi
+      cpu: 10m
   accessPolicy:
     inbound:
       rules:

--- a/prod-gcp-teamfamilie.yaml
+++ b/prod-gcp-teamfamilie.yaml
@@ -31,11 +31,11 @@ spec:
       enabled: true
   resources:
     limits:
-      memory: 1024Mi
+      memory: 500Mi
       cpu: "1"
     requests:
-      memory: 512Mi
-      cpu: 200m
+      memory: 300Mi
+      cpu: 50m
   accessPolicy:
     inbound:
       rules:

--- a/prod-gcp-teamfamilie.yaml
+++ b/prod-gcp-teamfamilie.yaml
@@ -32,7 +32,6 @@ spec:
   resources:
     limits:
       memory: 500Mi
-      cpu: "1"
     requests:
       memory: 300Mi
       cpu: 50m


### PR DESCRIPTION
Vanligvis ville jeg kjempet for at min minne limit er lik minne request, men ser at applikasjonen noen ganger kan ha spikes i minnebruk. Tenker derfor at det er greit at vi har mer i limit på minne som er høyere enn request, siden de ikke varer så lenge. 

Prod:
![image](https://github.com/navikt/familie-baks-soknad-api/assets/17828446/f74c27ac-1111-45db-b494-e3db7788a59b)

Dev: 
![image](https://github.com/navikt/familie-baks-soknad-api/assets/17828446/dba9fbdd-a16b-4241-9b7c-70aba54b7bfd)