### PR TITLE
Fjerner familie-ba-soknad-gammel-url fra inbound rules

### DIFF
--- a/dev-gcp-teamfamilie.yaml
+++ b/dev-gcp-teamfamilie.yaml
@@ -39,7 +39,6 @@ spec:
     inbound:
       rules:
         - application: familie-ba-soknad
-        - application: familie-ba-soknad-gammel-url
         - application: familie-ks-soknad
     outbound:
       rules:

--- a/prod-gcp-teamfamilie.yaml
+++ b/prod-gcp-teamfamilie.yaml
@@ -39,7 +39,6 @@ spec:
     inbound:
       rules:
         - application: familie-ba-soknad
-        - application: familie-ba-soknad-gammel-url
         - application: familie-ks-soknad
     outbound:
       rules:


### PR DESCRIPTION
Ble lagt inn i forbindelse med at det ble satt opp en egen app i kubernetes som skulle bruke gammel url. Brukes ikke lenger så fjerner det.