### PR TITLE
Bytter fra opplysningstype Foedsel til Foedselsdato

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/pdl/PdlHentPersonResponse.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/pdl/PdlHentPersonResponse.kt
@@ -24,7 +24,7 @@ data class PdlPersonData(
     val navn: List<PdlNavn>,
     val adressebeskyttelse: List<Adressebeskyttelse>,
     val forelderBarnRelasjon: List<PdlFamilierelasjon> = emptyList(),
-    val foedsel: List<PdlFødselsDato>,
+    val foedselsdato: List<PdlFødselsDato>,
     val bostedsadresse: List<Bostedsadresse?>,
     val statsborgerskap: List<PdlStatsborgerskap>,
     val sivilstand: List<PdlSivilstand>?,

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/services/pdl/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/services/pdl/PersonopplysningerService.kt
@@ -62,7 +62,7 @@ class PersonopplysningerService(
                     erBarnetsAlderUnderAldersgrenseForYtelse(
                         parseIsoDato(
                             it.data.person
-                                ?.foedsel
+                                ?.foedselsdato
                                 ?.firstOrNull()
                                 ?.foedselsdato
                         ),

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/services/pdl/mapper/PdlBarnMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/services/pdl/mapper/PdlBarnMapper.kt
@@ -43,7 +43,7 @@ object PdlBarnMapper {
                                 .fulltNavn()
                         },
                     fødselsdato =
-                        barnRespons.data.person.foedsel
+                        barnRespons.data.person.foedselsdato
                             .firstOrNull()
                             ?.foedselsdato,
                     borMedSøker =

--- a/src/main/resources/pdl/hent-person-med-relasjoner.graphql
+++ b/src/main/resources/pdl/hent-person-med-relasjoner.graphql
@@ -8,7 +8,7 @@ query ($ident: ID!) {
         folkeregisteridentifikator{
             identifikasjonsnummer
         }
-        foedsel {
+        foedselsdato {
             foedselsdato
         }
         doedsfall {

--- a/src/test/kotlin/no/nav/familie/baks/soknad/api/integrasjoner/ClientMocks.kt
+++ b/src/test/kotlin/no/nav/familie/baks/soknad/api/integrasjoner/ClientMocks.kt
@@ -106,7 +106,7 @@ class ClientMocks {
                                             type = SIVILSTANDSTYPE.GIFT
                                         )
                                     ),
-                                foedsel =
+                                foedselsdato =
                                     listOf(
                                         PdlFødselsDato(
                                             "2020-02-25"
@@ -140,7 +140,7 @@ class ClientMocks {
                         person =
                             PdlPersonData(
                                 navn = listOf(PdlNavn("Barn", etternavn = "Barnessen III")),
-                                foedsel = listOf(PdlFødselsDato("2022-01-01")),
+                                foedselsdato = listOf(PdlFødselsDato("2022-01-01")),
                                 bostedsadresse =
                                     listOf(
                                         Bostedsadresse(
@@ -179,7 +179,7 @@ class ClientMocks {
                         person =
                             PdlPersonData(
                                 navn = listOf(PdlNavn("Barn", etternavn = "Barnessen II")),
-                                foedsel = listOf(PdlFødselsDato("2008-10-01")),
+                                foedselsdato = listOf(PdlFødselsDato("2008-10-01")),
                                 bostedsadresse =
                                     listOf(
                                         Bostedsadresse(
@@ -219,7 +219,7 @@ class ClientMocks {
                         person =
                             PdlPersonData(
                                 navn = listOf(PdlNavn("Barn", etternavn = "Barnessen IV")),
-                                foedsel = listOf(PdlFødselsDato("2008-10-01")),
+                                foedselsdato = listOf(PdlFødselsDato("2008-10-01")),
                                 bostedsadresse =
                                     listOf(
                                         Bostedsadresse(

--- a/src/test/kotlin/no/nav/familie/baks/soknad/api/personopplysning/PersonopplysningerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/soknad/api/personopplysning/PersonopplysningerServiceTest.kt
@@ -363,7 +363,7 @@ class PersonopplysningerServiceTest {
                                     )
                                 ),
                             statsborgerskap = listOf(PdlStatsborgerskap("NOR")),
-                            foedsel = listOf(PdlFødselsDato(fødselsdato.format(DateTimeFormatter.ISO_DATE))),
+                            foedselsdato = listOf(PdlFødselsDato(fødselsdato.format(DateTimeFormatter.ISO_DATE))),
                             doedsfall = emptyList(),
                             sivilstand = emptyList(),
                             forelderBarnRelasjon = forelderBarnRelasjoner

--- a/src/test/resources/pdl/pdlBarnErDoed.json
+++ b/src/test/resources/pdl/pdlBarnErDoed.json
@@ -45,7 +45,7 @@
           "land": "NOR"
         }
       ],
-      "foedsel": [
+      "foedselsdato": [
         {
           "foedselsdato": "1920-02-10"
         }

--- a/src/test/resources/pdl/pdlBarnErOverAtten.json
+++ b/src/test/resources/pdl/pdlBarnErOverAtten.json
@@ -45,7 +45,7 @@
           "land": "NOR"
         }
       ],
-      "foedsel": [
+      "foedselsdato": [
         {
           "foedselsdato": "1990-02-10"
         }

--- a/src/test/resources/pdl/pdlBarnHarAdresseBeskyttelse.json
+++ b/src/test/resources/pdl/pdlBarnHarAdresseBeskyttelse.json
@@ -44,7 +44,7 @@
           "land": "NOR"
         }
       ],
-      "foedsel": [
+      "foedselsdato": [
         {
           "foedselsdato": "2017-02-10"
         }

--- a/src/test/resources/pdl/pdlBrukerMedBarnOverAtten.json
+++ b/src/test/resources/pdl/pdlBrukerMedBarnOverAtten.json
@@ -12,7 +12,7 @@
           "type": "GIFT"
         }
       ],
-      "foedsel": [
+      "foedselsdato": [
         {
           "foedselsdato": "1920-02-10"
         }

--- a/src/test/resources/pdl/pdlBrukerMedDoedBarn.json
+++ b/src/test/resources/pdl/pdlBrukerMedDoedBarn.json
@@ -12,7 +12,7 @@
           "type": "GIFT"
         }
       ],
-      "foedsel": [
+      "foedselsdato": [
         {
           "foedselsdato": "1920-02-10"
         }

--- a/src/test/resources/pdl/pdlMedMatrikkelAdresse.json
+++ b/src/test/resources/pdl/pdlMedMatrikkelAdresse.json
@@ -28,7 +28,7 @@
         }
       ],
       "doedsfall": [],
-      "foedsel": [
+      "foedselsdato": [
         {
           "foedselsdato": "1920-02-10"
         }

--- a/src/test/resources/pdl/pdlMedUkjentBosted.json
+++ b/src/test/resources/pdl/pdlMedUkjentBosted.json
@@ -24,7 +24,7 @@
         }
       ],
       "doedsfall": [],
-      "foedsel": [
+      "foedselsdato": [
         {
           "foedselsdato": "1920-02-10"
         }

--- a/src/test/resources/pdl/pdlPersonBarn.json
+++ b/src/test/resources/pdl/pdlPersonBarn.json
@@ -41,7 +41,7 @@
           "land": "NOR"
         }
       ],
-      "foedsel": [
+      "foedselsdato": [
         {
           "foedselsdato": "2018-02-10"
         }

--- a/src/test/resources/pdl/pdlPersonBarnGradertAdresse.json
+++ b/src/test/resources/pdl/pdlPersonBarnGradertAdresse.json
@@ -44,7 +44,7 @@
 
         }
       ],
-      "foedsel": [
+      "foedselsdato": [
         {
           "foedselsdato": "1920-02-10"
         }

--- a/src/test/resources/pdl/pdlPersonMedEttBarn.json
+++ b/src/test/resources/pdl/pdlPersonMedEttBarn.json
@@ -12,7 +12,7 @@
           "land": "NOR"
         }
       ],
-      "foedsel": [
+      "foedselsdato": [
         {
           "foedselsdato": "1920-02-10"
         }

--- a/src/test/resources/pdl/pdlPersonMedFlereRelasjoner.json
+++ b/src/test/resources/pdl/pdlPersonMedFlereRelasjoner.json
@@ -12,7 +12,7 @@
           "type": "GIFT"
         }
       ],
-      "foedsel": [
+      "foedselsdato": [
         {
           "foedselsdato": "1920-02-10"
         }

--- a/src/test/resources/pdl/pdlPersonMedFlereStatsborgerskap.json
+++ b/src/test/resources/pdl/pdlPersonMedFlereStatsborgerskap.json
@@ -13,7 +13,7 @@
           "gradering": "UGRADERT"
         }
       ],
-      "foedsel": [
+      "foedselsdato": [
         {
           "foedselsdato": "1920-02-10"
         }

--- a/src/test/resources/pdl/pdlPersonMedRelasjonerIngenBarn.json
+++ b/src/test/resources/pdl/pdlPersonMedRelasjonerIngenBarn.json
@@ -31,7 +31,7 @@
           "land": "NOR"
         }
       ],
-      "foedsel": [
+      "foedselsdato": [
         {
           "foedselsdato": "1920-02-10"
         }

--- a/src/test/resources/pdl/pdlPersonUtenRelasjoner.json
+++ b/src/test/resources/pdl/pdlPersonUtenRelasjoner.json
@@ -18,7 +18,7 @@
           "land": "NOR"
         }
       ],
-      "foedsel": [
+      "foedselsdato": [
         {
           "foedselsdato": "1920-02-10"
         }

--- a/src/test/resources/pdl/pdlPersonUtenRelasjonerGradertAdresse.json
+++ b/src/test/resources/pdl/pdlPersonUtenRelasjonerGradertAdresse.json
@@ -17,7 +17,7 @@
           "land": "NOR"
         }
       ],
-      "foedsel": [
+      "foedselsdato": [
         {
           "foedselsdato": "1920-02-10"
         }

--- a/src/test/resources/pdl/pdlSoekerHarAdresseOgAdressebeskyttelse.json
+++ b/src/test/resources/pdl/pdlSoekerHarAdresseOgAdressebeskyttelse.json
@@ -27,7 +27,7 @@
         }
       ],
       "doedsfall": [],
-      "foedsel": [
+      "foedselsdato": [
         {
           "foedselsdato": "1920-02-10"
         }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Opplysningstypen foedsel med foedselsdato splittes i foedselsdato og
foedested. Vi bruker foedselsdato, så bytter over til ny opplysningstype
[nav-it.slack.com/archives/C020Q1K6EAY/p1718099562666089](https://nav-it.slack.com/archives/C020Q1K6EAY/p1718099562666089)

```
hentPerson {
        foedselsdato {
            foedselsdato
            foedselsaar
            folkeregistermetadata {
                ...folkeregistermetadataDetails
            }
            metadata {
                ...metadataDetails
            }
        }
}
```

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
