### PR TITLE
Gjort ident/fnr nullable for barn

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/domene/Person.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/domene/Person.kt
@@ -14,7 +14,7 @@ data class Person(
 )
 
 data class Barn(
-    val ident: String,
+    val ident: String?,
     val navn: String?,
     val borMedSøker: Boolean,
     val fødselsdato: String?,

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/services/pdl/mapper/PdlBarnMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/services/pdl/mapper/PdlBarnMapper.kt
@@ -27,23 +27,25 @@ object PdlBarnMapper {
     ): Barn =
         Result
             .runCatching {
-                val barnHarAdresseBeskyttelse = harPersonAdresseBeskyttelse(barnRespons.data.person?.adressebeskyttelse)
+                val pdlPersonDataBarn = barnRespons.data.person!!
+                val barnHarAdresseBeskyttelse = harPersonAdresseBeskyttelse(pdlPersonDataBarn.adressebeskyttelse)
                 Barn(
                     ident =
-                        barnRespons.data.person
-                            ?.folkeregisteridentifikator
-                            ?.first()
-                            ?.identifikasjonsnummer!!,
+                        when (barnHarAdresseBeskyttelse) {
+                            true -> null
+                            false ->
+                                pdlPersonDataBarn.folkeregisteridentifikator.first().identifikasjonsnummer!!
+                        },
                     navn =
-                        if (barnHarAdresseBeskyttelse) {
-                            null
-                        } else {
-                            barnRespons.data.person.navn
-                                .firstOrNull()!!
-                                .fulltNavn()
+                        when (barnHarAdresseBeskyttelse) {
+                            true -> null
+                            false ->
+                                pdlPersonDataBarn.navn
+                                    .firstOrNull()!!
+                                    .fulltNavn()
                         },
                     fødselsdato =
-                        barnRespons.data.person.foedselsdato
+                        pdlPersonDataBarn.foedselsdato
                             .firstOrNull()
                             ?.foedselsdato,
                     borMedSøker =
@@ -53,7 +55,7 @@ object PdlBarnMapper {
                                 borBarnMedSoeker(
                                     soekerAdresse = soekerAdresse,
                                     barneAdresser =
-                                        barnRespons.data.person.bostedsadresse
+                                        pdlPersonDataBarn.bostedsadresse
                                             .filterNotNull()
                                 )
                         },

--- a/src/test/kotlin/no/nav/familie/baks/soknad/api/personopplysning/PersonopplysningerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/soknad/api/personopplysning/PersonopplysningerServiceTest.kt
@@ -253,8 +253,11 @@ class PersonopplysningerServiceTest {
         every { kodeverkClient.hentPostnummer() } returns kodeverkMockFor("kodeverkPostnummerRespons")
 
         val person = personopplysningerService.hentPersoninfo("1", Ytelse.BARNETRYGD)
-        assertTrue(person.barn.toList()[0].adressebeskyttelse)
-        assertFalse(person.barn.toList()[0].borMedSøker)
+        val barn = person.barn.toList()[0]
+        assertTrue(barn.adressebeskyttelse)
+        assertFalse(barn.borMedSøker)
+        assertEquals(barn.navn, null)
+        assertEquals(barn.ident, null)
     }
 
     @Test


### PR DESCRIPTION
Favro: [NAV-21626](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21626)

### 💰 Hva forsøker du å løse i denne PR'en
Ønsker ikke å eksponere fnr til barn med adressebeskyttelse via api og setter derfor fnr til null i disse tilfellene. 

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
