### PR TITLE
Fjerner barn fra respons som har adressebeskyttelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/services/pdl/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/services/pdl/PersonopplysningerService.kt
@@ -58,6 +58,8 @@ class PersonopplysningerService(
         fnrBarn
             .map { ident -> pdlApp2AppClient.hentPerson(ident, ytelse) }
             .filter {
+                !PdlMapper.harPersonAdresseBeskyttelse(it.data.person?.adressebeskyttelse)
+            }.filter {
                 erBarnILive(it.data.person?.doedsfall) &&
                     erBarnetsAlderUnderAldersgrenseForYtelse(
                         parseIsoDato(

--- a/src/test/kotlin/no/nav/familie/baks/soknad/api/personopplysning/PersonopplysningerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/soknad/api/personopplysning/PersonopplysningerServiceTest.kt
@@ -253,8 +253,7 @@ class PersonopplysningerServiceTest {
         every { kodeverkClient.hentPostnummer() } returns kodeverkMockFor("kodeverkPostnummerRespons")
 
         val person = personopplysningerService.hentPersoninfo("1", Ytelse.BARNETRYGD)
-        assertTrue(person.barn.toList()[0].adressebeskyttelse)
-        assertFalse(person.barn.toList()[0].borMedSøker)
+        assertTrue(person.barn.isEmpty())
     }
 
     @Test
@@ -275,9 +274,7 @@ class PersonopplysningerServiceTest {
         every { kodeverkClient.hentPostnummer() } returns kodeverkMockFor("kodeverkPostnummerRespons")
 
         val person = personopplysningerService.hentPersoninfo("1", Ytelse.BARNETRYGD)
-        assertTrue(person.barn.toList()[0].adressebeskyttelse)
-        assertEquals(person.barn.toList()[0].navn, null)
-        assertFalse(person.barn.toList()[0].borMedSøker)
+        assertTrue(person.barn.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Vi returnerer og viser barn med kode 6 og 7 i frontend, og dette kan vi ikke gjøre. Dette er særlig kritisk for barn med kode 6.

Fjerner derfor alle barn med adressebeskyttelse fra respons.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
