### PR TITLE
Omgjør kall fra Kontoregisteret til Ressurs

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/kontoregister/KontoregisterClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/kontoregister/KontoregisterClient.kt
@@ -17,10 +17,17 @@ class KontoregisterClient(
 ) : AbstractRestClient(restOperations, "kontoregister") {
     fun hentKontonummer(kontohaver: String): Ressurs<KontoregisterResponseDto> {
         val uri: URI = UriUtil.uri(URI.create(kontoregisterBaseUrl), "hent-aktiv-konto")
-        return postForEntity<Ressurs<KontoregisterResponseDto>>(
-            uri = uri,
-            payload = KontoregisterRequestDto(kontohaver)
-        )
+        val postForEntity =
+            postForEntity<KontoregisterResponseDto>(
+                uri = uri,
+                payload = KontoregisterRequestDto(kontohaver)
+            )
+
+        return if (postForEntity.kontonummer.isNotEmpty()) {
+            Ressurs.success(data = postForEntity)
+        } else {
+            Ressurs.failure("Klarte ikke finne kontonummer")
+        }
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/kontoregister/KontoregisterClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/kontoregister/KontoregisterClient.kt
@@ -2,7 +2,6 @@ package no.nav.familie.baks.soknad.api.clients.mottak
 
 import no.nav.familie.http.client.AbstractRestClient
 import no.nav.familie.http.util.UriUtil
-import no.nav.familie.kontrakter.felles.Ressurs
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -15,19 +14,12 @@ class KontoregisterClient(
     @Value("\${KONTOREGISTER_URL}") private val kontoregisterBaseUrl: String,
     @Qualifier("tokenExchange") private val restOperations: RestOperations
 ) : AbstractRestClient(restOperations, "kontoregister") {
-    fun hentKontonummer(kontohaver: String): Ressurs<KontoregisterResponseDto> {
+    fun hentKontonummer(kontohaver: String): KontoregisterResponseDto {
         val uri: URI = UriUtil.uri(URI.create(kontoregisterBaseUrl), "hent-aktiv-konto")
-        val postForEntity =
-            postForEntity<KontoregisterResponseDto>(
-                uri = uri,
-                payload = KontoregisterRequestDto(kontohaver)
-            )
-
-        return if (postForEntity.kontonummer.isNotEmpty()) {
-            Ressurs.success(data = postForEntity)
-        } else {
-            Ressurs.failure("Klarte ikke finne kontonummer")
-        }
+        return postForEntity<KontoregisterResponseDto>(
+            uri = uri,
+            payload = KontoregisterRequestDto(kontohaver)
+        )
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/controllers/KontoregisterController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/controllers/KontoregisterController.kt
@@ -23,6 +23,17 @@ class KontoregisterController(
     @GetMapping("/hent-kontonr")
     fun hentKontoForInnloggetBruker(): ResponseEntity<Ressurs<KontoregisterResponseDto>> {
         val fnr = EksternBrukerUtils.hentFnrFraToken()
-        return ResponseEntity.ok().body(kontoregisterClient.hentKontonummer(fnr))
+        val kontoregisterResponseDto = kontoregisterClient.hentKontonummer(kontohaver = fnr)
+
+        val body =
+            if (kontoregisterResponseDto.kontonummer.isNotEmpty()) {
+                Ressurs.success(
+                    data = kontoregisterResponseDto
+                )
+            } else {
+                Ressurs.failure("Klarte ikke finne kontonummer")
+            }
+
+        return ResponseEntity.ok().body(body)
     }
 }

--- a/src/test/kotlin/no/nav/familie/baks/soknad/api/kontoregister/KontoregisterTestConfig.kt
+++ b/src/test/kotlin/no/nav/familie/baks/soknad/api/kontoregister/KontoregisterTestConfig.kt
@@ -4,7 +4,6 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.baks.soknad.api.clients.mottak.KontoregisterClient
 import no.nav.familie.baks.soknad.api.clients.mottak.KontoregisterResponseDto
-import no.nav.familie.kontrakter.felles.Ressurs
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
@@ -17,11 +16,11 @@ class KontoregisterTestConfig {
     @Primary
     fun kontoregisterClientMock(): KontoregisterClient {
         val kontoregisterClient: KontoregisterClient = mockk()
-        val kontoregisterResponse =
+
+        every { kontoregisterClient.hentKontonummer(any()) } returns
             KontoregisterResponseDto(
                 "815.493.00"
             )
-        every { kontoregisterClient.hentKontonummer(any()) } returns Ressurs.success(kontoregisterResponse)
         return kontoregisterClient
     }
 }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Grunnen til at kallet feilet før var fordi vi antok at vi kunne caste responsen direkte til datatypen `Ressurs`. Men siden strukturen er annerledes, kan vi ikke det.

Dette kan testes i dev på url https://familie-ba-soknad.ekstern.dev.nav.no/barnetrygd/soknad/api/kontoregister/hent-kontonr med testpersoner som har/ikke har kontonummer satt.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Er dette en OK måte å caste om til `Ressurs` på? Kunne dette blitt gjort på en bedre måte?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Er liten vits å skrive tester for dette.

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
