### PR TITLE
Egen feilhåndtering når kontoregisteret svarer med 404, fjerner støy i loggene våre

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/kontoregister/KontoregisterClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/kontoregister/KontoregisterClient.kt
@@ -2,7 +2,6 @@ package no.nav.familie.baks.soknad.api.clients.mottak
 
 import no.nav.familie.http.client.AbstractRestClient
 import no.nav.familie.http.util.UriUtil
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
@@ -20,10 +19,6 @@ class KontoregisterClient(
             uri = uri,
             payload = KontoregisterRequestDto(kontohaver)
         )
-    }
-
-    companion object {
-        private val LOG = LoggerFactory.getLogger(MottakClient::class.java)
     }
 }
 


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22189

### 💰 Hva forsøker du å løse i denne PR'en
Hvis kontoregisteret svarer med 404 på uthenting av kontonummer er det helt ok, ikke alle har registrert kontonummer. Dette skal ikke komme i alerts-kanalene våre, det er unødvendig støy.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Usikker på om det gir så mye verdi å teste akkurat dette.

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
