### PR TITLE
Bruk clientCredential mot kodeverk

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/kodeverk/KodeverkClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/kodeverk/KodeverkClient.kt
@@ -4,6 +4,7 @@ import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.http.client.Pingable
 import no.nav.familie.http.util.UriUtil
 import no.nav.familie.kontrakter.felles.kodeverk.KodeverkDto
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestOperations
@@ -12,7 +13,7 @@ import java.net.URI
 @Component
 class KodeverkClient(
     @Value("\${KODEVERK_URL}") private val kodeverkBaseUrl: String,
-    restOperations: RestOperations
+    @Qualifier("clientCredential") private val restOperations: RestOperations
 ) : AbstractPingableRestClient(restOperations, "integrasjon"),
     Pingable {
     private val kodeverkUri: URI = URI.create(kodeverkBaseUrl)

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -3,6 +3,7 @@ PDL_URL: https://pdl-api.dev-fss-pub.nais.io
 PDL_AUDIENCE: dev-fss:pdl:pdl-api
 PDL_SCOPE: api://dev-fss.pdl.pdl-api/.default
 KODEVERK_URL: https://kodeverk-api.nav.no
+KODEVERK_SCOPE: api://dev-gcp.team-rocket.kodeverk-api/.default
 KONTOREGISTER_URL: http://sokos-kontoregister-person.okonomi/api/borger/v1
 
 no.nav.security.jwt:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -3,6 +3,7 @@ PDL_URL: https://pdl-api.prod-fss-pub.nais.io
 PDL_AUDIENCE: prod-fss:pdl:pdl-api
 PDL_SCOPE: api://prod-fss.pdl.pdl-api/.default
 KODEVERK_URL: https://kodeverk-api.nav.no
+KODEVERK_SCOPE: api://prod-gcp.team-rocket.kodeverk-api/.default
 KONTOREGISTER_URL: http://sokos-kontoregister-person.okonomi/api/borger/v1
 
 no.nav.security.jwt:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,6 +22,7 @@ management:
 FAMILIE_BAKS_MOTTAK_URL: dummy
 PDL_URL: dummy
 KODEVERK_URL: dummy
+KODEVERK_SCOPE: "dummy-scope"
 
 no.nav.security.jwt:
   issuer:
@@ -61,6 +62,15 @@ no.nav.security.jwt:
         token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
         grant-type: client_credentials
         scope: ${PDL_SCOPE}
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
+      kodeverk-clientcredentials:
+        resource-url: ${KODEVERK_URL}
+        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+        grant-type: client_credentials
+        scope: ${KODEVERK_SCOPE}
         authentication:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22730

Veldig fint hvis noen kan se på denne.
Har generelt lite kunnskap når det gjelder tokens, scope, credentials og alt annet knyttet til kall internt i NAV så rop ut hvis det er noe feil!

Funksjonelt testet ved å trigge kallet mot kodeverk etter kodeendringer.