### PR TITLE
Skrur ned loggnivå på AsyncRequestNotUsableException

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/config/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/config/ApiExceptionHandler.kt
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException
 
 @ControllerAdvice
 class ApiExceptionHandler {
@@ -32,6 +33,16 @@ class ApiExceptionHandler {
     fun handleGradertAdresseException(gradertAdresseException: GradertAdresseException): ResponseEntity<Ressurs<String>> {
         secureLogger.info("Spørring for person med gradert adresse avvist")
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Ressurs.ikkeTilgang("Ikke tilgang"))
+    }
+
+    /**
+     * AsyncRequestNotUsableException er en exception som blir kastet når en async request blir avbrutt. Velger
+     * å skjule denne exceptionen fra loggen da den ikke er interessant for oss.
+     */
+    @ExceptionHandler(AsyncRequestNotUsableException::class)
+    fun handlAsyncRequestNotUsableException(e: AsyncRequestNotUsableException): ResponseEntity<Any> {
+        LOG.info("En AsyncRequestNotUsableException har oppstått, som skjer når en async request blir avbrutt", e)
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()
     }
 
     companion object {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Gjør som i familie-integrasjoner. Skrur ned loggnivå på AsyncRequestNotUsableException, som skjer når en klient kutter connection

Disse dukker opp med alarmelding
En feil har oppstått: ServletOutputStream failed to write: null
