### PR TITLE
Pin GitHub Actions til commit SHA, fremfor versjonnummer

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,8 +11,10 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
+      interval: weekly
+      day: monday
+      time: "06:00"
+      open-pull-requests-limit: 10
   - package-ecosystem: maven
     directory: "/"
     schedule:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -13,7 +13,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   analyze:
@@ -36,54 +36,54 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'java-kotlin' ]
+        language: ['java-kotlin']
         # CodeQL supports [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
         # Use only 'java-kotlin' to analyze code written in Java, Kotlin or both
         # Use only 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@45775bd8235c68ba998cffa5171334d58593da47 # ratchet:github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
 
-    # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Sett opp java
-      uses: actions/setup-java@v4
-      with:
-        java-version: 21
-        distribution: 'temurin'
-        cache: 'maven'
-    - name: Bygg med maven
-      env:
-        GITHUB_USERNAME: x-access-token
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: mvn -B --no-transfer-progress compile --settings .m2/maven-settings.xml
+      # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Sett opp java
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # ratchet:actions/setup-java@v4ra
+        with:
+          java-version: 21
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Bygg med maven
+        env:
+          GITHUB_USERNAME: x-access-token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mvn -B --no-transfer-progress compile --settings .m2/maven-settings.xml
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
+      # - run: |
+      #     echo "Run, Build Application using script"
+      #     ./location_of_script_within_repo/buildscript.sh
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@45775bd8235c68ba998cffa5171334d58593da47 # ratchet:github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/build-maven-app.yaml@main
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/build-maven-app.yaml@79bff2aa2b3685aa9aaa55f232ccedd9ce11614b # ratchet:navikt/familie-baks-gha-workflows/.github/workflows/build-maven-app.yaml@main
     with:
       build-image: true
       push-image: true
@@ -33,8 +33,8 @@ jobs:
     name: Deploy dev
     permissions:
       id-token: write
-    needs: [ build ]
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@main
+    needs: [build]
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@79bff2aa2b3685aa9aaa55f232ccedd9ce11614b # ratchet:navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@main
     with:
       image: ${{ needs.build.outputs.image }}
       cluster: dev-gcp
@@ -44,8 +44,8 @@ jobs:
     name: Deploy prod
     permissions:
       id-token: write
-    needs: [ build, deploy-dev ]
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@main
+    needs: [build, deploy-dev]
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@79bff2aa2b3685aa9aaa55f232ccedd9ce11614b # ratchet:navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@main
     with:
       image: ${{ needs.build.outputs.image }}
       cluster: prod-gcp

--- a/.github/workflows/manual-deploy-dev.yaml
+++ b/.github/workflows/manual-deploy-dev.yaml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/build-maven-app.yaml@main
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/build-maven-app.yaml@79bff2aa2b3685aa9aaa55f232ccedd9ce11614b # ratchet:navikt/familie-baks-gha-workflows/.github/workflows/build-maven-app.yaml@main
     with:
       skip-tests: ${{ inputs.skip-tests }}
       build-image: true
@@ -24,8 +24,8 @@ jobs:
     name: Deploy with new image
     permissions:
       id-token: write
-    needs: [ build ]
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@main
+    needs: [build]
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@79bff2aa2b3685aa9aaa55f232ccedd9ce11614b # ratchet:navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@main
     with:
       image: ${{ needs.build.outputs.image }}
       cluster: dev-gcp

--- a/.github/workflows/manual-deploy-prod.yaml
+++ b/.github/workflows/manual-deploy-prod.yaml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/build-maven-app.yaml@main
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/build-maven-app.yaml@79bff2aa2b3685aa9aaa55f232ccedd9ce11614b # ratchet:navikt/familie-baks-gha-workflows/.github/workflows/build-maven-app.yaml@main
     with:
       skip-tests: ${{ inputs.skip-tests }}
       build-image: true
@@ -25,8 +25,8 @@ jobs:
     name: Deploy with new image
     permissions:
       id-token: write
-    needs: [ build ]
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@main
+    needs: [build]
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@79bff2aa2b3685aa9aaa55f232ccedd9ce11614b # ratchet:navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@main
     with:
       image: ${{ needs.build.outputs.image }}
       cluster: prod-gcp

--- a/.github/workflows/manual-deploy-with-image.yaml
+++ b/.github/workflows/manual-deploy-with-image.yaml
@@ -19,7 +19,7 @@ jobs:
     if: inputs.image != ''
     permissions:
       id-token: write
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy-with-tag.yaml@main
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy-with-tag.yaml@79bff2aa2b3685aa9aaa55f232ccedd9ce11614b # ratchet:navikt/familie-baks-gha-workflows/.github/workflows/deploy-with-tag.yaml@main
     with:
       image-tag: ${{ inputs.image }}
       cluster: ${{ inputs.environment }}-gcp

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -2,7 +2,7 @@ name: Pull request
 on:
   workflow_dispatch:
   pull_request:
-    types: [ opened, synchronize, reopened, ready_for_review ]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -16,12 +16,12 @@ jobs:
       contents: "read"
       id-token: "write"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
+      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # ratchet:actions/setup-java@v4
         with:
           java-version: 21
           distribution: 'temurin'
-      - uses: actions/cache@v4
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # ratchet:actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-cache-${{ hashFiles('pom.xml') }}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
NAV-24579

Ta i bruk ratchet og dependabot for workflow templates. Som vil gi oss up-to-date versjoner av workflows som blir brukt. Vi lærte i tech-prat at å lene seg på versjonnummer alene utgir en sikkerhetsrisiko.

