### PR TITLE
Fiks feilaktig indent i dependabot.yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,7 +14,7 @@ updates:
       interval: weekly
       day: monday
       time: "06:00"
-      open-pull-requests-limit: 10
+    open-pull-requests-limit: 10
   - package-ecosystem: maven
     directory: "/"
     schedule:


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Ble en indent for mye i tidligere PR. Nå skal det samsvare med schema.
