### PR TITLE
Fjern id token permission

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@ on:
     paths-ignore:
       - '**.md'
       - '**.MD'
-      - '.github/*.yaml'
+      - '.github/**.yaml'
       - '.gitignore'
       - 'CODEOWNERS'
       - 'LICENSE'

--- a/.github/workflows/scan-vulnerabilities.yaml
+++ b/.github/workflows/scan-vulnerabilities.yaml
@@ -9,7 +9,7 @@ on:
     paths-ignore:
       - '**.md'
       - '**.MD'
-      - '.github/*.yaml'
+      - '.github/**.yaml'
       - '.gitignore'
       - 'CODEOWNERS'
       - 'LICENSE'

--- a/.github/workflows/scan-vulnerabilities.yaml
+++ b/.github/workflows/scan-vulnerabilities.yaml
@@ -19,7 +19,6 @@ jobs:
     permissions:
       contents: write # to write sarif
       security-events: write # push sarif to github security
-      id-token: write # nais/login
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/scan-vulnerabilities-maven.yaml@main
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/scan-vulnerabilities-maven.yaml@95b1f0f855f8c73015db7b815d249ee11f035906 # ratchet:navikt/familie-baks-gha-workflows/.github/workflows/scan-vulnerabilities-maven.yaml@main
     secrets: inherit
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Siste versjon av scan-vulnerabilities trenger ikke id-token, fjerner derfor den for å følge 'principle of least privilege'.

I samme slengen fikses paths-ignore for workflow-filer, samt å pinne scan-vulnerabilities til SHA da dette var glemt.