### PR TITLE
Sett java versjon 25 for scan-vulnerabilities workflow

### DIFF
--- a/.github/workflows/scan-vulnerabilities.yaml
+++ b/.github/workflows/scan-vulnerabilities.yaml
@@ -21,5 +21,7 @@ jobs:
       security-events: write # push sarif to github security
       id-token: write # nais/login
     uses: navikt/familie-baks-gha-workflows/.github/workflows/scan-vulnerabilities-maven.yaml@main # ratchet:exclude
+    with:
+      java-version: '25'
     secrets: inherit
 


### PR DESCRIPTION
### 📮 Favro: NAV-28032

### 💰 Hva skal gjøres, og hvorfor?
Parameteret manglet etter oppgradering av java.