### PR TITLE
Byttet til validering av kontrakter fra kontraktspakka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jvmTarget>25</jvmTarget>
         <java.version>25</java.version>
-        <kontrakter.version>4.0_20260127095609_7f1d60a</kontrakter.version>
+        <kontrakter.version>4.0_20260423205840_8dec2cb</kontrakter.version>
         <felles.version>4.20260301040348_4280733</felles.version>
         <mockk.version>1.14.9</mockk.version>
         <nav.security.version>6.0.4</nav.security.version>

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/controllers/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/controllers/SøknadController.kt
@@ -5,7 +5,7 @@ import no.nav.familie.baks.soknad.api.services.BarnetrygdSøknadService
 import no.nav.familie.baks.soknad.api.services.KontantstøtteSøknadService
 import no.nav.familie.kontrakter.ba.søknad.v10.BarnetrygdSøknadV10Validator
 import no.nav.familie.kontrakter.felles.Ressurs
-import no.nav.familie.kontrakter.felles.søknad.Søknadsfelt
+import no.nav.familie.kontrakter.ks.søknad.v6.KontantstøtteSøknadV6Validator
 import no.nav.familie.sikkerhet.EksternBrukerUtils
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.api.RequiredIssuers
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import no.nav.familie.kontrakter.ba.søknad.v10.BarnetrygdSøknad as BarnetrygdSøknadV10
 import no.nav.familie.kontrakter.ba.søknad.v9.BarnetrygdSøknad as BarnetrygdSøknadV9
-import no.nav.familie.kontrakter.ks.søknad.v5.KontantstøtteSøknad as KontantstøtteSøknadV5
 import no.nav.familie.kontrakter.ks.søknad.v6.KontantstøtteSøknad as KontantstøtteSøknadV6
 
 @RestController
@@ -56,142 +55,12 @@ class SøknadController(
         @RequestBody(required = true)
         kontantstøtteSøknad: KontantstøtteSøknadV6
     ): ResponseEntity<Ressurs<Kvittering>> {
-        try {
-            kontantstøtteSøknad.valider()
-        } catch (e: Exception) {
-            logger.info("Validering av kontantstøtte-søknad feilet. Søknaden sendes videre til journalføring, men man bør se på hvorfor det feiler. Se securelogs for detaljer.")
-            secureLogger.info("Validering av kontantstøtte-søknad feilet", e)
+        val valideringsfeil = KontantstøtteSøknadV6Validator.valider(kontantstøtteSøknad)
+        if (valideringsfeil.isNotEmpty()) {
+            logger.info("Søknad av kontantstøtte(v6) mottatt med ${valideringsfeil.size} valideringsfeil. Søknaden sendes videre til journalføring, men man bør se på hvorfor det feiler. Se securelogs for detaljer.")
+            secureLogger.info("Validering av kontantstøtte-søknad feilet:\n $valideringsfeil")
         }
 
         return ResponseEntity.ok().body(kontantstøtteSøknadService.mottaOgSendKontantstøttesøknad(kontantstøtteSøknad))
-    }
-
-    @PostMapping("/soknad/kontantstotte/v5")
-    fun søknadsmottakKontantstøtte(
-        @RequestBody(required = true)
-        kontantstøtteSøknad: KontantstøtteSøknadV5
-    ): ResponseEntity<Ressurs<Kvittering>> {
-        try {
-            kontantstøtteSøknad.valider()
-        } catch (e: Exception) {
-            logger.info("Validering av kontantstøtte-søknad feilet. Søknaden sendes videre til journalføring, men man bør se på hvorfor det feiler. Se securelogs for detaljer.")
-            secureLogger.info("Validering av kontantstøtte-søknad feilet", e)
-        }
-
-        return ResponseEntity.ok().body(kontantstøtteSøknadService.mottaOgSendKontantstøttesøknad(kontantstøtteSøknad))
-    }
-}
-
-fun KontantstøtteSøknadV6.valider() {
-    søker.ident.verdi.values.forEach { fnr ->
-        require(fnr.all { it.isDigit() }) { "Ugyldig format på søker fødselsnummer" }
-    }
-
-    barn.forEach { barn ->
-        barn.ident.verdi.values.forEach { fnr ->
-            require(fnr.all { it.isDigit() }) { "Ugyldig format på barnets fødselsnummer" }
-        }
-        listOfNotNull(
-            barn.navn,
-            barn.adresse
-        ).forEach { textField ->
-            // valider alle verdier i tekstfelt
-            validerVerdiITextfelt(textField)
-            // valider alle labler i tekstfelt
-            validerLabel(textField)
-        }
-    }
-
-    // XSS prevention - sanitize text fields
-    listOfNotNull(
-        søker.navn,
-        søker.statsborgerskap,
-        søker.sivilstand,
-        søker.adresse
-    ).forEach { textField ->
-        // valider alle verdier i tekstfelt
-        validerVerdiITextfelt(textField)
-        // valider alle labler i tekstfelt
-        validerLabel(textField)
-    }
-    listOfNotNull(
-        søker.andreUtbetalingsperioder,
-        søker.pensjonsperioderNorge,
-        søker.idNummer,
-        søker.arbeidsperioderNorge,
-        søker.pensjonsperioderUtland,
-        søker.utenlandsperioder,
-        søker.arbeidsperioderUtland
-    ).forEach { liste ->
-        liste.forEach { textField ->
-            // valider alle verider i tekstfelt
-            validerVerdiITextfelt(textField)
-            // valider alle labler i tekstfelt
-            validerLabel(textField)
-        }
-    }
-}
-
-fun KontantstøtteSøknadV5.valider() {
-    søker.ident.verdi.values.forEach { fnr ->
-        require(fnr.all { it.isDigit() }) { "Ugyldig format på søker fødselsnummer" }
-    }
-
-    barn.forEach { barn ->
-        barn.ident.verdi.values.forEach { fnr ->
-            require(fnr.all { it.isDigit() }) { "Ugyldig format på barnets fødselsnummer" }
-        }
-        listOfNotNull(
-            barn.navn,
-            barn.adresse
-        ).forEach { textField ->
-            // valider alle verdier i tekstfelt
-            validerVerdiITextfelt(textField)
-            // valider alle labler i tekstfelt
-            validerLabel(textField)
-        }
-    }
-
-    // XSS prevention - sanitize text fields
-    listOfNotNull(
-        søker.navn,
-        søker.statsborgerskap,
-        søker.sivilstand,
-        søker.adresse
-    ).forEach { textField ->
-        // valider alle verdier i tekstfelt
-        validerVerdiITextfelt(textField)
-        // valider alle labler i tekstfelt
-        validerLabel(textField)
-    }
-    listOfNotNull(
-        søker.andreUtbetalingsperioder,
-        søker.pensjonsperioderNorge,
-        søker.idNummer,
-        søker.arbeidsperioderNorge,
-        søker.pensjonsperioderUtland,
-        søker.utenlandsperioder,
-        søker.arbeidsperioderUtland
-    ).forEach { liste ->
-        liste.forEach { textField ->
-            // valider alle verider i tekstfelt
-            validerVerdiITextfelt(textField)
-            // valider alle labler i tekstfelt
-            validerLabel(textField)
-        }
-    }
-}
-
-private fun validerLabel(textField: Søknadsfelt<out Any?>) {
-    textField.label.values.forEach { label ->
-        require(label.length < 200) { "Tekstfelt(label) er for langt. ${textField.label} " }
-        require(!Regex("[<>\"]").containsMatchIn(label)) { "Tekstfelt(label) inneholder ugyldige tegn. ${textField.label} " }
-    }
-}
-
-private fun validerVerdiITextfelt(textField: Søknadsfelt<out Any?>) {
-    textField.verdi.values.forEach { verdi ->
-        require(verdi.toString().length < 200) { "Tekstfelt er for langt. ${textField.verdi} " }
-        require(!Regex("[<>'\"]").containsMatchIn(verdi.toString())) { "Tekstfelt inneholder ugyldige tegn, ${textField.verdi} " }
     }
 }

--- a/src/test/kotlin/no/nav/familie/baks/soknad/api/controllers/SøknadControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/soknad/api/controllers/SøknadControllerTest.kt
@@ -10,8 +10,6 @@ import no.nav.familie.baks.soknad.api.services.KontantstøtteSøknadService
 import no.nav.familie.baks.soknad.api.services.KontantstøtteSøknadTestData
 import no.nav.familie.kontrakter.felles.Ressurs
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertThrows
-import org.junit.jupiter.api.Assertions.assertTrue
 import java.time.LocalDateTime
 import kotlin.test.Test
 
@@ -56,41 +54,5 @@ class SøknadControllerTest {
 
         assertEquals(200, response.statusCode.value())
         assertEquals(kvittering, response.body?.data)
-    }
-
-    @Test
-    fun søknadsmottakKontantstøtte_kaster_feil_ved_ugyldig_input() {
-        val søknad = KontantstøtteSøknadTestData.kontantstøtteSøknad(søker = KontantstøtteSøknadTestData.søker().copy(navn = søknadsfelt("navn", "Navn <>")))
-
-        val exception =
-            assertThrows(IllegalArgumentException::class.java) {
-                søknad.valider()
-            }
-
-        assertTrue(exception.message!!.startsWith("Tekstfelt inneholder ugyldige tegn"))
-    }
-
-    @Test
-    fun søknadsmottakKontantstøtte_kaster_feil_ved_for_lang_input() {
-        val søknad = KontantstøtteSøknadTestData.kontantstøtteSøknad(søker = KontantstøtteSøknadTestData.søker().copy(navn = søknadsfelt("navn", "Navn er over 200 tegn".padEnd(200, 'a'))))
-
-        val exception =
-            assertThrows(IllegalArgumentException::class.java) {
-                søknad.valider()
-            }
-
-        assertTrue(exception.message!!.startsWith("Tekstfelt er for langt"))
-    }
-
-    @Test
-    fun søknadsmottakKontantstøtte_kaster_feil_ved_for_lang_label() {
-        val søknad = KontantstøtteSøknadTestData.kontantstøtteSøknad(søker = KontantstøtteSøknadTestData.søker().copy(navn = søknadsfelt("navn".padEnd(200, 'a'), "Navn er over 200 tegn")))
-
-        val exception =
-            assertThrows(IllegalArgumentException::class.java) {
-                søknad.valider()
-            }
-
-        assertTrue(exception.message!!.startsWith("Tekstfelt(label) er for langt"))
     }
 }


### PR DESCRIPTION
### 📮 Favro: NAV-23039

### 💰 Hva skal gjøres, og hvorfor?
Bytter ut validering for kontantstøltte, med validering i kontrakter. Den i kontrakter validerer hele kontrakten og ikke noen utvalgte få felt.

Ryddet vekk ubrukt endepunkt for søknad som ikke eksisterer lenger

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
