### PR TITLE
Avvis søknader med valideringsfeil

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/controllers/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/controllers/SøknadController.kt
@@ -39,8 +39,9 @@ class SøknadController(
     ): ResponseEntity<Ressurs<Kvittering>> {
         val valideringsfeil = BarnetrygdSøknadV10Validator.valider(søknad)
         if (valideringsfeil.isNotEmpty()) {
-            logger.info("Søknad av barnetrygd(v10) mottatt med ${valideringsfeil.size} valideringsfeil. Søknaden sendes videre til journalføring, men man bør se på hvorfor det feiler. Se securelogs for detaljer.")
-            secureLogger.info("Validering av barnetrygd-søknad feilet:\n $valideringsfeil")
+            logger.error("Søknad av barnetrygd(v10) avvist med ${valideringsfeil.size} valideringsfeil")
+            secureLogger.error("Validering av barnetrygd-søknad feilet:\n $valideringsfeil")
+            return ResponseEntity.badRequest().body(Ressurs.failure("Søknaden har valideringsfeil i objectPaths: ${valideringsfeil.joinToString("\n") { it.objectPath }}"))
         }
         return ResponseEntity.ok().body(barnetrygdSøknadService.mottaOgSendBarnetrygdsøknad(søknad))
     }
@@ -57,8 +58,9 @@ class SøknadController(
     ): ResponseEntity<Ressurs<Kvittering>> {
         val valideringsfeil = KontantstøtteSøknadV6Validator.valider(kontantstøtteSøknad)
         if (valideringsfeil.isNotEmpty()) {
-            logger.info("Søknad av kontantstøtte(v6) mottatt med ${valideringsfeil.size} valideringsfeil. Søknaden sendes videre til journalføring, men man bør se på hvorfor det feiler. Se securelogs for detaljer.")
-            secureLogger.info("Validering av kontantstøtte-søknad feilet:\n $valideringsfeil")
+            logger.error("Søknad av kontantstøtte(v6) avvist med ${valideringsfeil.size} valideringsfeil")
+            secureLogger.error("Validering av kontantstøtte-søknad feilet:\n $valideringsfeil")
+            return ResponseEntity.badRequest().body(Ressurs.failure("Søknaden har valideringsfeil i objectPaths: ${valideringsfeil.joinToString("\n") { it.objectPath }}"))
         }
 
         return ResponseEntity.ok().body(kontantstøtteSøknadService.mottaOgSendKontantstøttesøknad(kontantstøtteSøknad))

--- a/src/test/kotlin/no/nav/familie/baks/soknad/api/controllers/SøknadControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/soknad/api/controllers/SøknadControllerTest.kt
@@ -10,6 +10,7 @@ import no.nav.familie.baks.soknad.api.services.KontantstøtteSøknadService
 import no.nav.familie.baks.soknad.api.services.KontantstøtteSøknadTestData
 import no.nav.familie.kontrakter.felles.Ressurs
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.springframework.http.HttpStatus
 import java.time.LocalDateTime
 import kotlin.test.Test
 
@@ -32,15 +33,15 @@ class SøknadControllerTest {
     }
 
     @Test
-    fun søknadsmottakBarnetrygd_logger_men_kaster_ikke_feil_ved_ugyldig_input() {
+    fun søknadsmottakBarnetrygd_returnerer_bad_request_ved_ugyldig_input() {
         val søknad = BarnetrygdSøknadTestData.barnetrygdSøknad(søker = BarnetrygdSøknadTestData.søker().copy(navn = søknadsfelt("navn", "Navn <>")))
         val kvittering = Kvittering("OK", LocalDateTime.now())
         every { barnetrygdSøknadService.mottaOgSendBarnetrygdsøknad(søknad) } returns Ressurs.success(kvittering)
 
         val response = søknadController.søknadsmottakBarnetrygd(søknad)
 
-        assertEquals(200, response.statusCode.value())
-        assertEquals(kvittering, response.body?.data)
+        assertEquals(HttpStatus.BAD_REQUEST.value(), response.statusCode.value())
+        assertEquals("Søknaden har valideringsfeil i objectPaths: søker.navn.verdi", response.body?.melding)
     }
 
     @Test


### PR DESCRIPTION
### 📮 Favro: NAV-23039

### 💰 Hva skal gjøres, og hvorfor?
Vi har logget valideringsfeil i kontraktene siden 24 april. På den tiden har man trigget 1 valideringsfeil(filnavn over 200 tegn) som ville ha ført til en avvist søknad.

Denne PRen skrur på inputvalidering. Dette betyr at søknader som ikke validerer vil bli avvist. Det vil generes en alarm. 

Frontend bør oppdateres med valideringer der det smeller

Dette pga økt sikkerhet

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
