### PR TITLE
Fjern ubrukt PDL url fra ingress

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -46,7 +46,6 @@ spec:
         - application: logging
           namespace: nais-system
       external:
-        - host: api-gw-q1.oera.no
         - host: login.microsoftonline.com
         - host: pdl-api.dev-fss-pub.nais.io
         - host: kodeverk-api.nav.no

--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -48,7 +48,6 @@ spec:
       external:
         - host: pdl-api.prod-fss-pub.nais.io
         - host: kodeverk-api.nav.no
-        - host: api-gw.oera.no
         - host: login.microsoftonline.com
   vault:
     enabled: false


### PR DESCRIPTION
### 📮 Favro: N/A

### 💰 Hva skal gjøres, og hvorfor?
Tilsynelatende en gateway URL for å nå PDL, er ikke brukt i kode, og ser ut til å være gammel moro.