### PR TITLE
Bytter fra oppretting av token ved å bruke nav-token-client/rest-klient til texas/token-klient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <jvmTarget>25</jvmTarget>
         <java.version>25</java.version>
         <kontrakter.version>4.0_20260505124916_025d466</kontrakter.version>
-        <felles.version>4.20260507085428_e5ad38a</felles.version>
+        <felles.version>4.20260513094924_5cc59b4</felles.version>
         <mockk.version>1.14.9</mockk.version>
         <nav.security.version>6.0.7</nav.security.version>
         <start-class>no.nav.familie.baks.soknad.api.LauncherKt</start-class>
@@ -99,8 +99,12 @@
         </dependency>
         <dependency>
             <groupId>no.nav.familie.felles</groupId>
-            <artifactId>rest-klient</artifactId>
+            <artifactId>token-klient</artifactId>
             <version>${felles.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
         </dependency>
         <dependency>
             <groupId>no.nav.familie.felles</groupId>
@@ -110,16 +114,6 @@
         <dependency>
             <groupId>no.nav.security</groupId>
             <artifactId>token-validation-spring</artifactId>
-            <version>${nav.security.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>no.nav.security</groupId>
-            <artifactId>token-client-spring</artifactId>
-            <version>${nav.security.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>no.nav.security</groupId>
-            <artifactId>token-client-core</artifactId>
             <version>${nav.security.version}</version>
         </dependency>
         <!-- https://github.com/spring-projects/spring-boot/issues/33044#issuecomment-1379812611 -->

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/kodeverk/KodeverkClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/kodeverk/KodeverkClient.kt
@@ -1,21 +1,18 @@
 package no.nav.familie.baks.soknad.api.clients.kodeverk
 
 import no.nav.familie.kontrakter.felles.kodeverk.KodeverkDto
-import no.nav.familie.restklient.client.AbstractPingableRestClient
-import no.nav.familie.restklient.client.Pingable
-import no.nav.familie.restklient.util.UriUtil
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
-import org.springframework.web.client.RestOperations
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.body
 import java.net.URI
 
 @Component
 class KodeverkClient(
     @Value("\${KODEVERK_URL}") private val kodeverkBaseUrl: String,
-    @Qualifier("clientCredential") private val restOperations: RestOperations
-) : AbstractPingableRestClient(restOperations, "integrasjon"),
-    Pingable {
+    @Qualifier("kodeverkRestClient") private val restClient: RestClient
+) {
     private val kodeverkUri: URI = URI.create(kodeverkBaseUrl)
 
     fun hentAlleLand(): KodeverkDto = getForEntity(uri = kodeverkUri("Landkoder"))
@@ -24,16 +21,27 @@ class KodeverkClient(
 
     fun hentPostnummer(): KodeverkDto = getForEntity(uri = kodeverkUri("Postnummer"))
 
+    fun ping() {
+        restClient
+            .get()
+            .uri(URI.create("$kodeverkBaseUrl/$PATH_PING"))
+            .retrieve()
+            .body<String>()
+    }
+
+    private fun getForEntity(uri: URI): KodeverkDto =
+        restClient
+            .get()
+            .uri(uri)
+            .retrieve()
+            .body<KodeverkDto>()!!
+
     fun kodeverkUri(
         kodeverksnavn: String,
         medHistorikk: Boolean = false
     ): URI {
         val query = if (medHistorikk) QUERY_MED_HISTORIKK else QUERY
-        return UriUtil.uri(
-            base = kodeverkUri,
-            path = "api/v1/kodeverk/$kodeverksnavn/koder/betydninger",
-            query = query
-        )
+        return URI.create("$kodeverkUri/api/v1/kodeverk/$kodeverksnavn/koder/betydninger?$query")
     }
 
     companion object {
@@ -41,6 +49,4 @@ class KodeverkClient(
         private const val QUERY = "ekskluderUgyldige=true&spraak=nb"
         private const val QUERY_MED_HISTORIKK = "ekskluderUgyldige=false&spraak=nb"
     }
-
-    override val pingUri: URI = UriUtil.uri(kodeverkUri, PATH_PING)
 }

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/kontoregister/KontoregisterClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/kontoregister/KontoregisterClient.kt
@@ -1,24 +1,27 @@
-package no.nav.familie.baks.soknad.api.clients.mottak
+package no.nav.familie.baks.soknad.api.clients.kontoregister
 
-import no.nav.familie.restklient.client.AbstractRestClient
-import no.nav.familie.restklient.util.UriUtil
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
-import org.springframework.web.client.RestOperations
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.body
 import java.net.URI
 
 @Component
 class KontoregisterClient(
     @Value("\${KONTOREGISTER_URL}") private val kontoregisterBaseUrl: String,
-    @Qualifier("tokenExchange") private val restOperations: RestOperations
-) : AbstractRestClient(restOperations, "kontoregister") {
+    @Qualifier("kontoregisterTokenXRestClient") private val restClient: RestClient
+) {
     fun hentKontonummer(kontohaver: String): KontoregisterResponseDto {
-        val uri: URI = UriUtil.uri(URI.create(kontoregisterBaseUrl), "hent-aktiv-konto")
-        return postForEntity<KontoregisterResponseDto>(
-            uri = uri,
-            payload = KontoregisterRequestDto(kontohaver)
-        )
+        val uri = URI.create("$kontoregisterBaseUrl/hent-aktiv-konto")
+        return restClient
+            .post()
+            .uri(uri)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(KontoregisterRequestDto(kontohaver))
+            .retrieve()
+            .body<KontoregisterResponseDto>()!!
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/mottak/MottakClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/mottak/MottakClient.kt
@@ -2,17 +2,17 @@ package no.nav.familie.baks.soknad.api.clients.mottak
 
 import no.nav.familie.baks.soknad.api.domene.Kvittering
 import no.nav.familie.kontrakter.felles.Ressurs
-import no.nav.familie.restklient.client.AbstractPingableRestClient
-import no.nav.familie.restklient.client.MultipartBuilder
-import no.nav.familie.restklient.util.UriUtil
+import no.nav.familie.kontrakter.felles.jsonMapper
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.http.HttpMethod
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
-import org.springframework.util.MultiValueMap
-import org.springframework.web.client.RestOperations
-import org.springframework.web.client.exchange
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.body
 import tools.jackson.databind.JsonNode
 import java.net.URI
 import no.nav.familie.kontrakter.ba.søknad.v10.BarnetrygdSøknad as BarnetrygdSøknadV10
@@ -23,13 +23,16 @@ import no.nav.familie.kontrakter.ks.søknad.v6.KontantstøtteSøknad as Kontants
 @Component
 class MottakClient(
     @Value("\${FAMILIE_BAKS_MOTTAK_URL}") private val mottakBaseUrl: String,
-    @Qualifier("tokenExchange") private val restOperations: RestOperations
-) : AbstractPingableRestClient(restOperations, "integrasjon") {
-    override val pingUri: URI = UriUtil.uri(URI.create(mottakBaseUrl), "api/soknad")
-
-    override fun ping() {
+    @Qualifier("mottakTokenXRestClient") private val restClient: RestClient
+) {
+    fun ping() {
+        val pingUri = URI.create("$mottakBaseUrl/api/soknad")
         try {
-            restOperations.exchange<JsonNode>(pingUri, HttpMethod.OPTIONS)
+            restClient
+                .options()
+                .uri(pingUri)
+                .retrieve()
+                .body<JsonNode>()
             LOG.debug("Ping mot familie-baks-mottak OK")
         } catch (e: Exception) {
             LOG.warn("Ping mot familie-baks-mottak feilet")
@@ -38,22 +41,22 @@ class MottakClient(
     }
 
     fun sendBarnetrygdSøknad(søknad: BarnetrygdSøknadV10): Ressurs<Kvittering> {
-        val uri: URI = UriUtil.uri(URI.create(mottakBaseUrl), "api/soknad/v10")
+        val uri = URI.create("$mottakBaseUrl/api/soknad/v10")
         return håndterSendingAvSøknad(uri = uri, søknad = søknad)
     }
 
     fun sendBarnetrygdSøknad(søknad: BarnetrygdSøknadV9): Ressurs<Kvittering> {
-        val uri: URI = UriUtil.uri(URI.create(mottakBaseUrl), "api/soknad/v9")
+        val uri = URI.create("$mottakBaseUrl/api/soknad/v9")
         return håndterSendingAvSøknad(uri = uri, søknad = søknad)
     }
 
     fun sendKontantstøtteSøknad(kontantstøtteSøknad: KontantstøtteSøknadV6): Ressurs<Kvittering> {
-        val uri: URI = UriUtil.uri(URI.create(mottakBaseUrl), "api/kontantstotte/soknad/v6")
+        val uri = URI.create("$mottakBaseUrl/api/kontantstotte/soknad/v6")
         return håndterSendingAvSøknad(uri = uri, søknad = kontantstøtteSøknad)
     }
 
     fun sendKontantstøtteSøknad(kontantstøtteSøknad: KontantstøtteSøknadV5): Ressurs<Kvittering> {
-        val uri: URI = UriUtil.uri(URI.create(mottakBaseUrl), "api/kontantstotte/soknad/v5")
+        val uri = URI.create("$mottakBaseUrl/api/kontantstotte/soknad/v5")
         return håndterSendingAvSøknad(uri = uri, søknad = kontantstøtteSøknad)
     }
 
@@ -62,14 +65,22 @@ class MottakClient(
         søknad: Any
     ): Ressurs<Kvittering> {
         try {
-            val multipartBuilder = MultipartBuilder().withJson("søknad", søknad)
-            val payload: MultiValueMap<String, Any> = multipartBuilder.build()
+            val jsonBytes = jsonMapper.writeValueAsBytes(søknad)
+            val jsonHeaders = HttpHeaders()
+            jsonHeaders.contentType = MediaType.APPLICATION_JSON
+            val jsonPart = HttpEntity<ByteArray>(jsonBytes, jsonHeaders)
+
+            val multipartBody = LinkedMultiValueMap<String, Any>()
+            multipartBody.add("søknad", jsonPart)
+
             val response =
-                postForEntity<Ressurs<Kvittering>>(
-                    uri = uri,
-                    payload = payload,
-                    httpHeaders = MultipartBuilder.MULTIPART_HEADERS
-                )
+                restClient
+                    .post()
+                    .uri(uri)
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .body(multipartBody)
+                    .retrieve()
+                    .body<Ressurs<Kvittering>>()!!
             LOG.info("Sende søknad til mottak OK: ${response.data}")
             return response
         } catch (e: Exception) {

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/pdl/PdlApp2AppClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/pdl/PdlApp2AppClient.kt
@@ -3,10 +3,10 @@ package no.nav.familie.baks.soknad.api.clients.pdl
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
-import org.springframework.web.client.RestOperations
+import org.springframework.web.client.RestClient
 
 @Component
 class PdlApp2AppClient(
-    @Value("\${PDL_URL}") private val pdlBaseUrl: String,
-    @Qualifier("clientCredential") private val restOperations: RestOperations
-) : PdlClient(pdlBaseUrl, restOperations)
+    @Value("\${PDL_URL}") pdlBaseUrl: String,
+    @Qualifier("pdlClientCredentialRestClient") restClient: RestClient
+) : PdlClient(pdlBaseUrl, restClient)

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/pdl/PdlBrukerClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/pdl/PdlBrukerClient.kt
@@ -3,10 +3,10 @@ package no.nav.familie.baks.soknad.api.clients.pdl
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
-import org.springframework.web.client.RestOperations
+import org.springframework.web.client.RestClient
 
 @Component
 class PdlBrukerClient(
-    @Value("\${PDL_URL}") private val pdlBaseUrl: String,
-    @Qualifier("tokenExchange") private val restOperations: RestOperations
-) : PdlClient(pdlBaseUrl, restOperations)
+    @Value("\${PDL_URL}") pdlBaseUrl: String,
+    @Qualifier("pdlTokenXRestClient") restClient: RestClient
+) : PdlClient(pdlBaseUrl, restClient)

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/clients/pdl/PdlClient.kt
@@ -2,24 +2,20 @@ package no.nav.familie.baks.soknad.api.clients.pdl
 
 import com.fasterxml.jackson.databind.JsonNode
 import no.nav.familie.baks.soknad.api.domene.Ytelse
-import no.nav.familie.restklient.client.AbstractPingableRestClient
-import no.nav.familie.restklient.client.Pingable
-import no.nav.familie.restklient.util.UriUtil
 import org.apache.commons.lang3.StringUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.http.HttpHeaders
-import org.springframework.http.HttpMethod
-import org.springframework.web.client.RestOperations
-import org.springframework.web.client.exchange
+import org.springframework.http.MediaType
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.body
 import java.net.URI
 
 abstract class PdlClient(
     pdlBaseUrl: String,
-    private val restOperations: RestOperations
-) : AbstractPingableRestClient(restOperations, "pdl.integrasjon"),
-    Pingable {
-    private val pdlUri = UriUtil.uri(base = URI.create(pdlBaseUrl), path = "graphql")
+    private val restClient: RestClient
+) {
+    private val pdlUri = URI.create("$pdlBaseUrl/graphql")
+    private val secureLogger: Logger = LoggerFactory.getLogger("secureLogger")
 
     fun hentPerson(
         personIdent: String,
@@ -38,11 +34,16 @@ abstract class PdlClient(
             )
 
         val response =
-            postForEntity<PdlHentPersonResponse>(
-                uri = pdlUri,
-                payload = pdlPersonRequest,
-                httpHeaders = httpHeaders(ytelse)
-            )
+            restClient
+                .post()
+                .uri(pdlUri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .headers { headers ->
+                    headers.add("Tema", ytelse.tema.name)
+                    headers.add("behandlingsnummer", ytelse.tema.behandlingsnummer)
+                }.body(pdlPersonRequest)
+                .retrieve()
+                .body<PdlHentPersonResponse>()!!
 
         if (response.harFeil()) {
             LOG.error("Feil ved henting av person fra PDL. Se securelogs for detaljer.")
@@ -64,18 +65,13 @@ abstract class PdlClient(
         return response
     }
 
-    private fun httpHeaders(ytelse: Ytelse): HttpHeaders =
-        HttpHeaders().apply {
-            add("Tema", ytelse.tema.name)
-            add("behandlingsnummer", ytelse.tema.behandlingsnummer)
-        }
-
-    override val pingUri: URI
-        get() = pdlUri
-
-    override fun ping() {
+    fun ping() {
         try {
-            restOperations.exchange<JsonNode>(pdlUri, HttpMethod.OPTIONS)
+            restClient
+                .options()
+                .uri(pdlUri)
+                .retrieve()
+                .body<JsonNode>()
             LOG.debug("Ping mot PDL-API OK")
         } catch (e: Exception) {
             LOG.warn("Ping mot PDL-API feilet")

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/config/ApplicationConfig.kt
@@ -2,34 +2,26 @@ package no.nav.familie.baks.soknad.api.config
 
 import no.nav.familie.log.NavSystemtype
 import no.nav.familie.log.filter.LogFilter
-import no.nav.familie.restklient.interceptor.BearerTokenClientCredentialsClientInterceptor
-import no.nav.familie.restklient.interceptor.BearerTokenExchangeClientInterceptor
-import no.nav.familie.restklient.interceptor.ConsumerIdClientInterceptor
-import no.nav.familie.restklient.interceptor.MdcValuesPropagatingClientInterceptor
+import no.nav.familie.log.interceptor.ConsumerIdClientInterceptor
+import no.nav.familie.log.interceptor.MdcValuesPropagatingClientInterceptor
 import no.nav.familie.sikkerhet.context.FamilieFellesNavTokenSupportKonfigurasjon
-import no.nav.security.token.support.client.spring.oauth2.EnableOAuth2Client
 import org.slf4j.LoggerFactory
 import org.springframework.boot.SpringBootConfiguration
-import org.springframework.boot.restclient.RestTemplateBuilder
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Import
-import org.springframework.context.annotation.Primary
-import org.springframework.web.client.RestOperations
-import java.time.Duration
-import java.time.temporal.ChronoUnit
 
 @SpringBootConfiguration
-@ComponentScan(ApplicationConfig.PAKKENAVN)
+@ComponentScan(
+    ApplicationConfig.PAKKENAVN,
+    "no.nav.familie.felles.tokenklient"
+)
 @Import(
     MdcValuesPropagatingClientInterceptor::class,
     ConsumerIdClientInterceptor::class,
-    BearerTokenExchangeClientInterceptor::class,
-    BearerTokenClientCredentialsClientInterceptor::class,
     FamilieFellesNavTokenSupportKonfigurasjon::class
 )
-@EnableOAuth2Client(cacheEnabled = true)
 internal class ApplicationConfig {
     @Bean
     fun logFilter(): FilterRegistrationBean<LogFilter> {
@@ -39,45 +31,6 @@ internal class ApplicationConfig {
         filterRegistration.order = 1
         return filterRegistration
     }
-
-    @Bean
-    @Primary
-    fun restTemplate(consumerIdClientInterceptor: ConsumerIdClientInterceptor): RestOperations =
-        RestTemplateBuilder()
-            .interceptors(
-                consumerIdClientInterceptor,
-                MdcValuesPropagatingClientInterceptor()
-            ).build()
-
-    @Bean("clientCredential")
-    fun clientCredentialRestTemplateMedApiKey(
-        consumerIdClientInterceptor: ConsumerIdClientInterceptor,
-        bearerTokenClientCredentialsClientInterceptor: BearerTokenClientCredentialsClientInterceptor,
-        mdcValuesPropagatingClientInterceptor: MdcValuesPropagatingClientInterceptor
-    ): RestOperations =
-        RestTemplateBuilder()
-            .connectTimeout(Duration.of(5, ChronoUnit.SECONDS))
-            .readTimeout(Duration.of(25, ChronoUnit.SECONDS))
-            .interceptors(
-                consumerIdClientInterceptor,
-                bearerTokenClientCredentialsClientInterceptor,
-                mdcValuesPropagatingClientInterceptor
-            ).build()
-
-    @Bean("tokenExchange")
-    fun tokenExchangeRestTemplate(
-        bearerTokenExchangeClientInterceptor: BearerTokenExchangeClientInterceptor,
-        mdcValuesPropagatingClientInterceptor: MdcValuesPropagatingClientInterceptor,
-        consumerIdClientInterceptor: ConsumerIdClientInterceptor
-    ): RestOperations =
-        RestTemplateBuilder()
-            .connectTimeout(Duration.of(5, ChronoUnit.SECONDS))
-            .readTimeout(Duration.of(25, ChronoUnit.SECONDS))
-            .interceptors(
-                bearerTokenExchangeClientInterceptor,
-                mdcValuesPropagatingClientInterceptor,
-                consumerIdClientInterceptor
-            ).build()
 
     companion object {
         private val logger = LoggerFactory.getLogger(ApplicationConfig::class.java)

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/config/RestClientConfig.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/config/RestClientConfig.kt
@@ -1,0 +1,61 @@
+package no.nav.familie.baks.soknad.api.config
+
+import no.nav.familie.felles.tokenklient.entraid.EntraIDRestClientFactory
+import no.nav.familie.felles.tokenklient.tokenx.TokenXClient
+import no.nav.familie.log.interceptor.ConsumerIdClientInterceptor
+import no.nav.familie.log.interceptor.MdcValuesPropagatingClientInterceptor
+import no.nav.familie.sikkerhet.EksternBrukerUtils
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.RestClient
+
+@Configuration
+class RestClientConfig(
+    private val entraIDRestClientFactory: EntraIDRestClientFactory,
+    private val consumerIdClientInterceptor: ConsumerIdClientInterceptor,
+    private val mdcValuesPropagatingClientInterceptor: MdcValuesPropagatingClientInterceptor
+) {
+    @Bean("pdlClientCredentialRestClient")
+    fun pdlClientCredentialRestClient(
+        @Value("\${PDL_SCOPE}") scope: String
+    ): RestClient = entraIDRestClientFactory.lagMaskinTilMaskinRestKlient(scope)
+
+    @Bean("kodeverkRestClient")
+    fun kodeverkRestClient(
+        @Value("\${KODEVERK_SCOPE}") scope: String
+    ): RestClient = entraIDRestClientFactory.lagMaskinTilMaskinRestKlient(scope)
+
+    @Bean("mottakTokenXRestClient")
+    fun mottakTokenXRestClient(
+        tokenXClient: TokenXClient,
+        @Value("\${MOTTAK_SCOPE}") scope: String
+    ): RestClient = lagTokenXRestClient(tokenXClient, scope)
+
+    @Bean("kontoregisterTokenXRestClient")
+    fun kontoregisterTokenXRestClient(
+        tokenXClient: TokenXClient,
+        @Value("\${KONTOREGISTER_SCOPE}") scope: String
+    ): RestClient = lagTokenXRestClient(tokenXClient, scope)
+
+    @Bean("pdlTokenXRestClient")
+    fun pdlTokenXRestClient(
+        tokenXClient: TokenXClient,
+        @Value("\${PDL_TOKENX_SCOPE}") scope: String
+    ): RestClient = lagTokenXRestClient(tokenXClient, scope)
+
+    private fun lagTokenXRestClient(
+        tokenXClient: TokenXClient,
+        scope: String
+    ): RestClient =
+        RestClient
+            .builder()
+            .requestInterceptor { request, body, execution ->
+                val userToken = EksternBrukerUtils.getBearerTokenForLoggedInUser()
+                val token = tokenXClient.hentToken(scope, userToken)
+                request.headers.setBearerAuth(token)
+                execution.execute(request, body)
+            }.requestInterceptor(consumerIdClientInterceptor)
+            .requestInterceptor(mdcValuesPropagatingClientInterceptor)
+            .build()
+}

--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/controllers/KontoregisterController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/controllers/KontoregisterController.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.baks.soknad.api.controllers
 
-import no.nav.familie.baks.soknad.api.clients.mottak.KontoregisterClient
-import no.nav.familie.baks.soknad.api.clients.mottak.KontoregisterResponseDto
+import no.nav.familie.baks.soknad.api.clients.kontoregister.KontoregisterClient
+import no.nav.familie.baks.soknad.api.clients.kontoregister.KontoregisterResponseDto
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.sikkerhet.EksternBrukerUtils
 import no.nav.security.token.support.core.api.ProtectedWithClaims

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,19 +1,11 @@
 FAMILIE_BAKS_MOTTAK_URL: http://familie-baks-mottak
 PDL_URL: https://pdl-api.dev-fss-pub.nais.io
-PDL_AUDIENCE: dev-fss:pdl:pdl-api
 PDL_SCOPE: api://dev-fss.pdl.pdl-api/.default
+PDL_TOKENX_SCOPE: dev-fss:pdl:pdl-api
 KODEVERK_URL: https://kodeverk-api.nav.no
 KODEVERK_SCOPE: api://dev-gcp.team-rocket.kodeverk-api/.default
 KONTOREGISTER_URL: http://sokos-kontoregister-person.okonomi/api/borger/v1
-
-no.nav.security.jwt:
-  client:
-    registration:
-      mottak-clientcredentials:
-        token-exchange:
-          audience: dev-gcp:teamfamilie:familie-baks-mottak
-      kontoregister-clientcredentials:
-        token-exchange:
-          audience: dev-gcp:okonomi:sokos-kontoregister-person
+KONTOREGISTER_SCOPE: dev-gcp:okonomi:sokos-kontoregister-person
+MOTTAK_SCOPE: dev-gcp:teamfamilie:familie-baks-mottak
 
 logging.level.no.nav.security: INFO

--- a/src/main/resources/application-lokal.yaml
+++ b/src/main/resources/application-lokal.yaml
@@ -1,42 +1,21 @@
 FAMILIE_BAKS_MOTTAK_URL: http://localhost:8090
 PDL_URL: http://localhost:1337/rest/api/pdl
-PDL_AUDIENCE: dev-fss:pdl:pdl-api-q1
 PDL_SCOPE: api://dev-fss.pdl.pdl-api-q1/.default
+PDL_TOKENX_SCOPE: dev-fss:pdl:pdl-api-q1
 KODEVERK_URL: #Mockes lokalt
+KODEVERK_SCOPE: dummy
 KONTOREGISTER_URL: http://sokos-kontoregister-person.okonomi/api/borger/v1
+KONTOREGISTER_SCOPE: dummy
+MOTTAK_SCOPE: dummy
 
-PDL_API_APIKEY: test-apikey
-MOTTAK_APIKEY: test-apikey
-KODEVERK_API_KEY: test-apikey
+NAIS_TOKEN_ENDPOINT: http://localhost
+NAIS_TOKEN_EXCHANGE_ENDPOINT: http://localhost
 
 TOKEN_X_WELL_KNOWN_URL: https://fakedings.intern.dev.nav.no/fake/.well-known/openid-configuration
-TOKEN_X_PRIVATE_JWK: '{
- "use": "sig",
- "kty": "RSA",
- "kid": "4c8ad38a-a9ef-46bc-883f-50677f0a257a",
- "n": "pZ1CeQ5gqINv_FMM2y3cUpLR6LClAgCZ1HEQrSBAT9ivdyZ-V9k-3hVzd-6Pwxrhmoxk9ivGgLF94_2Ebyf0hiwJKRNnRYB6ilIKZxynCIDxYiboRoxHsMClFkVqX4-4JuEvHOb3vIm5rOfmAud3Z6RGGu74KutPiuo5u7-hpxyJ1p1xJPIuncUV8AaZIntfpi6DqD60McAre0MBsjcgnU97-rBklBN6si7lDCOCD0HVl24Aw1YjqxjSqc5A4MuAvRTHXYHzVLg6merDoC4AGx82VoqjKN-d7Jp49px5bTKqDwz6TyAY-qjJzv7GRgKEwwoD-IqsuP6MYcVPe2186Q",
- "e": "AQAB",
- "d": "dpLTZuzeU4hXg2bKy5pYJl6sH1dprLdVa_7Pm8R9hy1y43IR_z-xfTwKghGxqFT0tbxTBNVut_FcWwHF8fe_YNjibiBQTjigg6wdepnPFY2MRWPp5ajGI0yqZfmpIWY6yMts-dp8AObyo1MdIXMr0G6TKvFxiPkU6Dauwzd-u6_SP7tmg9wmnnMwkJSg3KZCS_7aDLXy4dU1tzagc5EeNrStUui7ycwAA-vszBWVSpcvJq6pw6ZxheBAM-ArngVtOG-5p6IE0g3baRNg2qbPVf6PUCllEKFXSvVm351LCWekjqrYkKCyEQnuY7SB_yNFh8KmcYEBpDulfp-OMBXzqQ",
- "p": "zjl8KI64ytGctHuGLMQ_kXNMX2LKuqEQk1HN4S_DyoRnB7d09FYm3iBE9V9nuc-zfc173ydwjujU4NjoWzyUG2SGV9I5IJi4VkdgZfyc82EsRa9dADr3f2rm8K4NlXcQ48IxGLtyoqByfH21qasp3gPjL-CNg4drRaYLp8c_PjM",
- "q": "zZZ8l22V1NQrAT9mEEm5cBsGKTpEvX9QXsZdxE3vS3LLQRP2V3KTEi1O2tgd0QrLlLh88qSoZIQwmQE5WklqCpU7OO80dZ0BrzAqDGEPvCONoOJnO5WQK8ulcjx3kY1i9iKzApDdzCcaAtM9Ri4zxYMafHjB0RMf4uO4zK-FRHM",
- "dp": "N1M4ufDAJrlhXxIchvoHS9Aw1w478SGwvrUdlKIp1rT6pxlSqRJLzx-9IE7-Ft1f_Aoah12fVtej9MZ8X6261jZ7zCe758DRA2SWugWxXaHeLLvFKYCoUWiumDc5sbWFtHSuk0IGmRaOYFOhXulqjANi-b82d-jmoILRcauEjf0",
- "dq": "U9q8qNsm0O9VNyYP0Dbx7xrmsWw124ERXAbW-hm7r-97neixgsuV10Ups7OQvdIEZX22YRXuJUmRtOa96Oim2vgxdrCCmjJXHIitreztCRULUILoDnKbonFm4yhssK6VncVbdIF4JiwQvPRCOtzfewFVjU2H6Go_iEDQAJTa66c",
- "qi": "xjuRb0uidaayF7YXF6DIKFmkXI8445KoFFGR_xCzBaM6BAtNWhhmGL6xQwblzbHnPqlNeestVPX2Eq7EQ0bkDQOG97-zl--nzO97FkRIGl2wfQstbrQxGVuHCTWjOxcf0NDZZ3oO4jnEdmnwwQofkPLRipxrybLIIlw4fBaB0f4"
-}'
 TOKEN_X_CLIENT_ID: dev-local:teamfamilie:familie-baks-soknad-api
-AZURE_OPENID_CONFIG_TOKEN_ENDPOINT: http://localhost
 
 no.nav.security.jwt:
   issuer:
     tokenx:
       discoveryurl: https://fakedings.intern.dev.nav.no/fake/.well-known/openid-configuration
       accepted_audience: dev-gcp:teamfamilie:familie-baks-soknad-api
-  client:
-    registration:
-      mottak-clientcredentials:
-        # bytt ut token-endpoint-url: http://metadata med grant-type: client_credentials dersom man skal kjøre api med mottak lokalt.
-        token-endpoint-url: http://metadata # Uten denne prøver token-support å kalle well-known uri i contructor og krasjer appen
-      pdl:
-        token-endpoint-url: http://metadata
-CREDENTIAL_USERNAME: dummy
-CREDENTIAL_PASSWORD: dummy

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,19 +1,11 @@
 FAMILIE_BAKS_MOTTAK_URL: http://familie-baks-mottak
 PDL_URL: https://pdl-api.prod-fss-pub.nais.io
-PDL_AUDIENCE: prod-fss:pdl:pdl-api
 PDL_SCOPE: api://prod-fss.pdl.pdl-api/.default
+PDL_TOKENX_SCOPE: prod-fss:pdl:pdl-api
 KODEVERK_URL: https://kodeverk-api.nav.no
 KODEVERK_SCOPE: api://prod-gcp.team-rocket.kodeverk-api/.default
 KONTOREGISTER_URL: http://sokos-kontoregister-person.okonomi/api/borger/v1
-
-no.nav.security.jwt:
-  client:
-    registration:
-      mottak-clientcredentials:
-        token-exchange:
-          audience: prod-gcp:teamfamilie:familie-baks-mottak
-      kontoregister-clientcredentials:
-        token-exchange:
-          audience: prod-gcp:okonomi:sokos-kontoregister-person
+KONTOREGISTER_SCOPE: prod-gcp:okonomi:sokos-kontoregister-person
+MOTTAK_SCOPE: prod-gcp:teamfamilie:familie-baks-mottak
 
 logging.level.no.nav.security: INFO

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,57 +23,15 @@ FAMILIE_BAKS_MOTTAK_URL: dummy
 PDL_URL: dummy
 KODEVERK_URL: dummy
 KODEVERK_SCOPE: "dummy-scope"
+PDL_SCOPE: "dummy-scope"
+PDL_TOKENX_SCOPE: "dummy-scope"
+MOTTAK_SCOPE: "dummy-scope"
+KONTOREGISTER_SCOPE: "dummy-scope"
 
 no.nav.security.jwt:
   issuer:
     tokenx:
       discovery-url: ${TOKEN_X_WELL_KNOWN_URL}
       accepted-audience: ${TOKEN_X_CLIENT_ID}
-  client:
-    registration:
-      mottak-clientcredentials:
-        resource-url: ${FAMILIE_BAKS_MOTTAK_URL}
-        well-known-url: ${TOKEN_X_WELL_KNOWN_URL}
-        grant-type: urn:ietf:params:oauth:grant-type:token-exchange
-        authentication:
-          client-id: ${TOKEN_X_CLIENT_ID}
-          client-auth-method: private_key_jwt
-          client-jwk: ${TOKEN_X_PRIVATE_JWK}
-      kontoregister-clientcredentials:
-        resource-url: ${KONTOREGISTER_URL}
-        well-known-url: ${TOKEN_X_WELL_KNOWN_URL}
-        grant-type: urn:ietf:params:oauth:grant-type:token-exchange
-        authentication:
-          client-id: ${TOKEN_X_CLIENT_ID}
-          client-auth-method: private_key_jwt
-          client-jwk: ${TOKEN_X_PRIVATE_JWK}
-      pdl:
-        resource-url: ${PDL_URL}
-        well-known-url: ${TOKEN_X_WELL_KNOWN_URL}
-        grant-type: urn:ietf:params:oauth:grant-type:token-exchange
-        token-exchange:
-          audience: ${PDL_AUDIENCE}
-        authentication:
-          client-id: ${TOKEN_X_CLIENT_ID}
-          client-auth-method: private_key_jwt
-          client-jwk: ${TOKEN_X_PRIVATE_JWK}
-      pdl-clientcredentials:
-        resource-url: ${PDL_URL}
-        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
-        grant-type: client_credentials
-        scope: ${PDL_SCOPE}
-        authentication:
-          client-id: ${AZURE_APP_CLIENT_ID}
-          client-secret: ${AZURE_APP_CLIENT_SECRET}
-          client-auth-method: client_secret_basic
-      kodeverk-clientcredentials:
-        resource-url: ${KODEVERK_URL}
-        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
-        grant-type: client_credentials
-        scope: ${KODEVERK_SCOPE}
-        authentication:
-          client-id: ${AZURE_APP_CLIENT_ID}
-          client-secret: ${AZURE_APP_CLIENT_SECRET}
-          client-auth-method: client_secret_basic
 
 logging.level.no.nav.security: DEBUG

--- a/src/test/kotlin/no/nav/familie/baks/soknad/api/kontoregister/KontoregisterTestConfig.kt
+++ b/src/test/kotlin/no/nav/familie/baks/soknad/api/kontoregister/KontoregisterTestConfig.kt
@@ -2,8 +2,8 @@ package no.nav.familie.baks.soknad.api.kontoregister
 
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.familie.baks.soknad.api.clients.mottak.KontoregisterClient
-import no.nav.familie.baks.soknad.api.clients.mottak.KontoregisterResponseDto
+import no.nav.familie.baks.soknad.api.clients.kontoregister.KontoregisterClient
+import no.nav.familie.baks.soknad.api.clients.kontoregister.KontoregisterResponseDto
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary


### PR DESCRIPTION
### 📮 Favro: NAV-29115

### 💰 Hva skal gjøres, og hvorfor? 
Endrer metode for å hente token. Tidligere brukte man nav-token-client med vårt eget interne bibliotek. Her har man gått over til texas og token-klient for å hente token. I tilllegg bytter man fra gammel RestTempate til mer oppdaterte Springs RestClient. 

### Oppdateringer av avhengigheter og biblioteker: 
Erstattet rest-klient-avhengigheten med token-klient og fjernet token-client-spring- og token-client-core-avhengighetene i pom.xml. La til caffeine-biblioteket for caching. Oppdaterte felles.version-egenskapen.

###Omarbeiding av klienter: 
Migrerte alle tilpassede klienter (KodeverkClient, KontoregisterClient, MottakClient, PdlClient, PdlBrukerClient, PdlApp2AppClient) fra å bruke RestOperations og restklient-abstraksjoner til å bruke Springs RestClient.

### Forenkling av konfigurasjon: 
Fjernet alle RestTemplate- og restklient-spesifikke bean-definisjoner fra ApplicationConfig.kt. Oppdaterte konfigurasjonen til kun å inkludere relevante logging- og token-støttebeans, og la til skanning for det nye tokenklient-pakken.

### Opprydding og forenkling av kode: 
Erstattet bruk av hjelpeklasser som UriUtil og MultipartBuilder med direkte URI-konstruksjon og standard Spring-klasser for håndtering av multipart og JSON.

### Justeringer av pakker og importer: 
Oppdaterte pakkeimporter for å fjerne referanser til det gamle restklient-biblioteket og bruke de aktuelle nye klassene og pakkene.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
