### PR TITLE
Senker loggnivå ned til warn for å unngå alarmer for valderingsfeil

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/controllers/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/controllers/SøknadController.kt
@@ -33,8 +33,8 @@ class SøknadController(
     ): ResponseEntity<Ressurs<Kvittering>> {
         val valideringsfeil = BarnetrygdSøknadV10Validator.valider(søknad)
         if (valideringsfeil.isNotEmpty()) {
-            logger.error("Søknad av barnetrygd(v10) avvist med ${valideringsfeil.size} valideringsfeil")
-            secureLogger.error("Validering av barnetrygd-søknad feilet:\n $valideringsfeil")
+            logger.warn("Søknad av barnetrygd(v10) avvist med ${valideringsfeil.size} valideringsfeil")
+            secureLogger.warn("Validering av barnetrygd-søknad feilet:\n $valideringsfeil")
             return ResponseEntity.badRequest().body(Ressurs.failure("Søknaden har valideringsfeil i objectPaths: ${valideringsfeil.joinToString("\n") { it.objectPath }}"))
         }
         return ResponseEntity.ok().body(barnetrygdSøknadService.mottaOgSendBarnetrygdsøknad(søknad))
@@ -52,8 +52,8 @@ class SøknadController(
     ): ResponseEntity<Ressurs<Kvittering>> {
         val valideringsfeil = KontantstøtteSøknadV6Validator.valider(kontantstøtteSøknad)
         if (valideringsfeil.isNotEmpty()) {
-            logger.error("Søknad av kontantstøtte(v6) avvist med ${valideringsfeil.size} valideringsfeil")
-            secureLogger.error("Validering av kontantstøtte-søknad feilet:\n $valideringsfeil")
+            logger.warn("Søknad av kontantstøtte(v6) avvist med ${valideringsfeil.size} valideringsfeil")
+            secureLogger.warn("Validering av kontantstøtte-søknad feilet:\n $valideringsfeil")
             return ResponseEntity.badRequest().body(Ressurs.failure("Søknaden har valideringsfeil i objectPaths: ${valideringsfeil.joinToString("\n") { it.objectPath }}"))
         }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Senker loggnivå for valideringsfeil til å ikke trigge alarm. Dette fordi den har kjørt nå et par måneder i prod med ERROR, og de feilene som har dukket opp er kjente og fikset i frontend. Samtidig er det en mellomlagret søknad som en bruker prøver å sende inn hver halvtime som trigger alarm
