### PR TITLE
fix: increase readTimeout for mottak REST client to 45s

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/config/RestClientConfig.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/config/RestClientConfig.kt
@@ -9,7 +9,9 @@ import no.nav.familie.sikkerhet.EksternBrukerUtils
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.client.JettyClientHttpRequestFactory
 import org.springframework.web.client.RestClient
+import java.time.Duration
 
 @Configuration
 class RestClientConfig(
@@ -31,7 +33,19 @@ class RestClientConfig(
     fun mottakTokenXRestClient(
         tokenXClient: TokenXClient,
         @Value("\${MOTTAK_SCOPE}") scope: String
-    ): RestClient = lagTokenXRestClient(tokenXClient, scope)
+    ): RestClient {
+        val requestFactory =
+            JettyClientHttpRequestFactory().apply {
+                setReadTimeout(Duration.ofSeconds(45))
+            }
+        return RestClient
+            .builder()
+            .requestFactory(requestFactory)
+            .requestInterceptor(TokenXInterceptor(tokenXClient, scope) { EksternBrukerUtils.getBearerTokenForLoggedInUser() })
+            .requestInterceptor(consumerIdClientInterceptor)
+            .requestInterceptor(mdcValuesPropagatingClientInterceptor)
+            .build()
+    }
 
     @Bean("kontoregisterTokenXRestClient")
     fun kontoregisterTokenXRestClient(


### PR DESCRIPTION
### 📮 Favro: NAV-29927

### 💰 Hva skal gjøres, og hvorfor?
Øker readTimeout for mottakTokenXRestClient fra 10s til 45s.

Søknader sendt til familie-baks-mottak feilet med TimeoutException etter nøyaktig 10 sekunder. Årsaken er at Spring sin JettyClientHttpRequestFactory har en hardkodet default readTimeout på 10 sekunder som overstyrer Jetty HttpClient sin native default (ingen timeout). Denne factoryen brukes automatisk fordi appen kjører på Jetty som servlet-container, noe som gjør at Jetty-klientbibliotekene er tilgjengelige på classpath.

Mottak bruker lengre tid enn dette på å prosessere søknaden når det er veldig mange vedlegg

Løsning: mottakTokenXRestClient bygger nå sin egen RestClient med eksplisitt 45s readTimeout via JettyClientHttpRequestFactory. Andre klienter er ikke berørt.

<img width="1517" height="862" alt="image" src="https://github.com/user-attachments/assets/7d30b5ca-9054-40bf-afea-e8aacc802e24" />



### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
