### PR TITLE
Scan kun relevante felles-komponenter

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/soknad/api/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/familie/baks/soknad/api/config/ApplicationConfig.kt
@@ -15,7 +15,8 @@ import org.springframework.context.annotation.Import
 @SpringBootConfiguration
 @ComponentScan(
     ApplicationConfig.PAKKENAVN,
-    "no.nav.familie.felles.tokenklient"
+    "no.nav.familie.felles.tokenklient.entraid",
+    "no.nav.familie.felles.tokenklient.tokenx"
 )
 @Import(
     MdcValuesPropagatingClientInterceptor::class,


### PR DESCRIPTION
### 📮 Favro: N/A

### 💰 Hva skal gjøres, og hvorfor?
Etter endring her: https://github.com/navikt/familie-felles/pull/960 ble STS klient også forsøkt scannet og wire-et. Noe som ikke bygger uten å sette irrelvante config-verdier. Spisser scanningen til kun entraid og tokenx. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
