### PR TITLE
NAV-29997: Legger til tokenx-token-generator i inbound rules

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -38,6 +38,9 @@ spec:
       rules:
         - application: familie-ba-soknad
         - application: familie-ks-soknad
+        - application: tokenx-token-generator
+          namespace: nais
+          cluster: dev-gcp
     outbound:
       rules:
         - application: familie-baks-mottak


### PR DESCRIPTION
### 📮 Favro: [NAV-29997](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-29997)

### 💰 Hva skal gjøres, og hvorfor?
I forbindelse med å kunne kjøre lokal ba/ks-soknad mot baks-soknad-api i dev må vi tillate at `tokenx-token-generator` kan kalle på baks-soknad-api i dev. `tokenx-token-generator` skal generere tokens for ba/ks-soknad.

Legger derfor her til `tokenx-token-generator` i inbound.rules i `app-dev.yaml`.
